### PR TITLE
Add a section for using the string module

### DIFF
--- a/src/tour/strings.md
+++ b/src/tour/strings.md
@@ -18,3 +18,15 @@ Special characters such as `"` need to be escaped with a `\` character.
 ```rust,noplaypen
 "Here is a double quote -> \" <-"
 ```
+
+## Manipulating strings.
+
+The `string` module implements functions for working with strings in Gleam.
+
+```rust,noplaypen
+import gleam/string
+
+let reversed = string.reverse("hello")
+
+reversed // => "olleh"
+```


### PR DESCRIPTION
I think this would be helpful to add on this page.
Makes calling functions on modules show up earlier in the walkthrough.