### PR TITLE
Update code examples in the Language tour

### DIFF
--- a/src/tour/comments.md
+++ b/src/tour/comments.md
@@ -29,7 +29,6 @@ pub fn add(x, y) {
 Comments may also be indented:
 
 ```rust,noplaypen
-
 pub fn multiply(x, y) {
   // here we are multiplying x by y
   x * y 

--- a/src/tour/constants.md
+++ b/src/tour/constants.md
@@ -3,7 +3,7 @@
 Gleam's module constants provide a way to use a certain fixed value in
 multiple places in a Gleam project.
 
-```rust
+```rust,noplaypen
 pub const start_year: = 2101
 pub const end_year: = 2111
 
@@ -22,7 +22,7 @@ changed, so they cannot be used as global mutable state.
 When a constant is referenced the value is inlined by the compiler, so they
 can be used in case expression guards.
 
-```rust
+```rust,noplaypen
 pub const start_year: Int = 2101
 pub const end_year: Int = 2111
 


### PR DESCRIPTION
In the comments tour, there was an unnecessary empty line that was being rendered at the beginning of a code example.
It's now removed.

In the constants tour, code examples were missing a `noplaypen` annotation, so they had the "run" and "show hidden code" buttons showing up (not functional). It is now added.