### PR TITLE
Fix typo on running the project page

### DIFF
--- a/docs/writing-gleam/running-the-project.html
+++ b/docs/writing-gleam/running-the-project.html
@@ -187,7 +187,7 @@ the expression otherwise the shell won't do anything.</p>
 <h2><a class="header" href="#releases" id="releases">Releases</a></h2>
 <p>To be run in production Erlang based applications are build into a deployable
 bundle called a release.</p>
-<p>At a later date will will have built in support and documentation for release,
+<p>At a later date we will have built in support and documentation for release,
 but for now please refer to these Erlang docs:</p>
 <ul>
 <li>https://adoptingerlang.org/docs/production/releases/</li>

--- a/src/writing-gleam/running-the-project.md
+++ b/src/writing-gleam/running-the-project.md
@@ -58,7 +58,7 @@ the expression otherwise the shell won't do anything.
 To be run in production Erlang based applications are build into a deployable
 bundle called a release.
 
-At a later date will will have built in support and documentation for release,
+At a later date we will have built in support and documentation for release,
 but for now please refer to these Erlang docs:
 
 - https://adoptingerlang.org/docs/production/releases/


### PR DESCRIPTION
Noticed that on the last paragraph of "Running the project" there is this sentence: `At a later date will will have built in support and [...]`. I guess there was a mistake and it was meant to be `we will`, or maybe `Gleam will`. This is just a fix for that.