### PR TITLE
Fix sponsor url redirects

### DIFF
--- a/_layouts/top.html
+++ b/_layouts/top.html
@@ -48,7 +48,7 @@
       <ul>
 {% assign sponsors = site.data.sponsors | sort: "name" %}
 {% for member in sponsors %}
-        <li><a href="{{ url }}">{{ member.name }}</a>
+        <li><a href="{{ member.url }}">{{ member.name }}</a>
 {% endfor %}
       </ul>
 {% endif %}


### PR DESCRIPTION
# Overview

I noticed that the sponsor links on the gleam website were not redirecting to the sponsors' GitHub profiles properly, so if you click on one it just refreshes the main gleam page.

It was a minor issue in the `top.html` layout. It is now getting the url from the sponsor data.