### PR TITLE
Add bit_builder import to web server example

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,7 @@ pub fn main() {
     HTTP request made to it.
 
 {% highlight rust %}
+import gleam/bit_builder
 import gleam/http/elli
 import gleam/http
 


### PR DESCRIPTION
Otherwise it does not compile.

I might be failing to understand something but it seems necessary? I've put it at the top to be alphabetical.