### PR TITLE
Correct a typo

### DIFF
--- a/cheatsheets/gleam-for-elixir-users.md
+++ b/cheatsheets/gleam-for-elixir-users.md
@@ -122,7 +122,7 @@ fn calculate(x) {
 
 In Elixir functions defined by `def` are public by default, while ones defined by `defp` are private.
 
-In Gleam functions are priavate by default and need `pub` keyword to be public.
+In Gleam functions are private by default and need the `pub` keyword to be public.
 
 #### Elixir
 


### PR DESCRIPTION
Tiny correction to the “Gleam for Elixir users” docs.