### PR TITLE
Style `code` in lists too

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -174,7 +174,8 @@ figure.highlight {
   overflow-x: auto;
 }
 
-p code {
+p code,
+li code {
   background-color: var(--color-light-grey);
   padding: 0 1px;
 }


### PR DESCRIPTION
Currently the code styling is limited to 'p' tags but 'li' tags don't have a nested 'p' tag so we need to account for them too.