### PR TITLE
Move types & optionality to new lines

### DIFF
--- a/writing-gleam/gleam-toml.md
+++ b/writing-gleam/gleam-toml.md
@@ -6,26 +6,34 @@ layout: page
 All Gleam projects require a `gleam.toml` configuration file. The configuration file allows you to
 specify the following properties:
 
-## `name` (string - required)
+## `name`
+
+`string` - *required*
 
 The name of your project. It should start with a lowercase letter and only contain lowercase letters
 and underscores.
 
-## `version` (string - optional)
+## `version`
+
+`string` - *optional*
 
 A version string. The version can be in any format.
 
 Note: This does not determine the version of the hex.pm package page when publishing your
 project. That is determined by the `vsn` entry in the `src/*.app.src` file in your project.
 
-## `description` (string - optional)
+## `description`
+
+`string` - *optional*
 
 A description of your project.
 
 Note: This does not determine the description on the hex.pm project page when publishing your
 project. That is determined by the `description` entry in the `src/*.app.src` file in your project.
 
-## `docs` (section - optional)
+## `docs`
+
+`section` - *optional*
 
 Determines what is included in the documentation. Includes `links` and `pages`.
 
@@ -35,7 +43,9 @@ links = ...
 pages = ...
 ```
 
-### `docs.pages` (list - optional)
+### `docs.pages`
+
+`list` - *optional*
 
 A set of additional markdown pages to be included in the generated documentation. Useful for
 including long form information on aspects of your project that are not covered by module specific
@@ -54,7 +64,9 @@ pages = [
 ]
 ```
 
-### `docs.links` (list - optional)
+### `docs.links`
+
+`list` - *optional*
 
 A list of links to be included in the side navigation bar of the generated documentation. In the
 format:


### PR DESCRIPTION
Otherwise the headers become quite long and wrap awkwardly on mobile screens.

Currently:
![image](https://user-images.githubusercontent.com/5390/99901646-f4080f80-2caf-11eb-83d9-2aaffe456f10.png)

With change:
![image](https://user-images.githubusercontent.com/5390/99901650-fcf8e100-2caf-11eb-8630-e8bae7497a25.png)

Sorry the images come out so large.