### PR TITLE
Make 'Note' bold

### DIFF
--- a/writing-gleam/gleam-toml.md
+++ b/writing-gleam/gleam-toml.md
@@ -15,14 +15,14 @@ and underscores.
 
 A version string. The version can be in any format.
 
-Note: This does not determine the version of the hex.pm package page when publishing your
+**Note**: This does not determine the version of the hex.pm package page when publishing your
 project. That is determined by the `vsn` entry in the `src/*.app.src` file in your project.
 
 ## `description` (string - optional)
 
 A description of your project.
 
-Note: This does not determine the description on the hex.pm project page when publishing your
+**Note**: This does not determine the description on the hex.pm project page when publishing your
 project. That is determined by the `description` entry in the `src/*.app.src` file in your project.
 
 ## `docs` (section - optional)


### PR DESCRIPTION
Minor and subjective change. Our 'bold' doesn't pop too much so this just serves to separate the 'Note:' label from its contents a little for clarity.

Sorry this is so minor. It is just a personal preference of mine that I should have included in the first pass. Feel free to ignore if you have a preference against it. 