### PR TITLE
[v0.13] Include 'repository' field in gleam.toml docs

### DIFF
--- a/writing-gleam/gleam-toml.md
+++ b/writing-gleam/gleam-toml.md
@@ -31,6 +31,22 @@ A description of your project.
 **Note**: This does not determine the description on the hex.pm project page when publishing your
 project. That is determined by the `description` entry in the `src/*.app.src` file in your project.
 
+## `repository`
+
+`object` - *optional*
+
+Specifies the online source repository for this project's code.
+
+This enables source links, in the generated documentation, from types, constants & functions to
+their defining lines of code in the repository.
+
+```toml
+repository = { type = "GitHub", user = "example", repo = "project" }
+repository = { type = "GitLab", user = "example", repo = "project" }
+repository = { type = "BitBucket", user = "example", repo = "project" }
+repository = { type = "Custom", url = "https://repo.example.com" }
+```
+
 ## `docs`
 
 `section` - *optional*


### PR DESCRIPTION
Designed to be merged when 0.13 is release so it is on a `0.13-changes` branch. Happy to rename if you'd like to take another approach. Just wanted this to be set and ready.

I'll rebase so it only includes the second commit if you merge the first in the other PR. (And if you don't think I'll remove it from this one.) I just figure they'll probably clash so leaving it here seems reasonable.