### PR TITLE
Provide links to toml.io

### DIFF
--- a/writing-gleam/gleam-toml.md
+++ b/writing-gleam/gleam-toml.md
@@ -3,8 +3,10 @@ title: gleam.toml
 layout: page
 ---
 
-All Gleam projects require a `gleam.toml` configuration file. The configuration file allows you to
-specify the following properties:
+All Gleam projects require a `gleam.toml` configuration file. The `toml` configuration format is
+documented at [Toml.io](https://toml.io/).
+
+The `gleam.toml` configuration file allows you to specify the following properties:
 
 ## `name`
 


### PR DESCRIPTION
Pretty subjective. I can understand if you consider it overkill. Especially with the repetition but I kind of think that within reason the more explanation & context the better.

---

To make it easier for beginner's to understand the reference.

Based in the fact that tables in toml can be flattened out to multiple
lines of variables and given that that syntax is used in some gleam
projects, it feels like it makes sense to draw attention to the
potential representation.