### PR TITLE
Add Language Tour to end of Getting Started.

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -158,3 +158,7 @@ niceties.
 - **Emacs** - [https://github.com/gleam-lang/gleam-mode](https://github.com/gleam-lang/gleam-mode)
 - **Visual Studio Code** - [https://github.com/rawburt/vscode-gleam-syntax](https://github.com/rawburt/vscode-gleam-syntax)
 - **Sublime Text 3** - [https://github.com/molnarmark/sublime-gleam](https://github.com/molnarmark/sublime-gleam)
+
+---
+
+[Language Tour](/book/tour) - In this chapter we explore the fundamentals of the Gleam language, namely its syntax, core data structures, flow control features, and static type system.


### PR DESCRIPTION
I am just starting gleam and wanted to add this. I read the getting started and then I had to scroll up to find the language tour part. But it wasn't on this page anywhere and had to go to the previous page. 

This adds it at the very bottom so those going through the same flow can get a next step.