### PR TITLE
Add Getting Started link on index

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@ list_sponsors: true
       Gleam is a fast, friendly, and functional language for building safe,
       scalable systems! ✨
     </h2>
+    <button class="btn btn-block"><a href="/">Get Started</a></button>
   </div>
 </section>
 
@@ -145,7 +146,4 @@ fn start_process(i) {
     libraries full of building blocks for writing type safe and fault
     tolerant multi-core programs as quickly as possible.
   </details>
-  
-  <h3>Interested?</h3>
-  <p><a href="/getting-started">Get started with Gleam on Linux, Windows, and macOS!</a></p>
 </section>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ list_sponsors: true
       Gleam is a fast, friendly, and functional language for building safe,
       scalable systems! ✨
     </h2>
-    <button class="btn btn-block"><a href="/">Get Started</a></button>
+    <button class="btn btn-block"><a href="/getting-started">Get Started</a></button>
   </div>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -145,5 +145,7 @@ fn start_process(i) {
     libraries full of building blocks for writing type safe and fault
     tolerant multi-core programs as quickly as possible.
   </details>
-
+  
+  <h3>Interested?</h3>
+  <p><a href="/getting-started">Get started with Gleam on Linux, Windows, and macOS!</a></p>
 </section>


### PR DESCRIPTION
My initial goal was I already knew about gleam but I need to get it installed. The path was `docs -> getting started` so this adds it on the homepage.

![Screenshot_2020-11-30 Gleam](https://user-images.githubusercontent.com/15027/100675256-9d947400-3334-11eb-9917-d8ca2a81b3a0.png)
