### PR TITLE
Provide an escript main function signature in the documentation

### DIFF
--- a/writing-gleam/running-the-project.md
+++ b/writing-gleam/running-the-project.md
@@ -85,10 +85,10 @@ pub external type CharList
 external fn char_list_to_string(CharList) -> String =
   "erlang" "list_to_binary"
 
-pub fn main(args_erlang: List(CharList)) {
-  let args = args_erlang |> list.map(char_list_to_string)
+pub fn main(args: List(CharList)) {
+  let args = list.map(args, char_list_to_string)
   
-  ...
+  todo("Your code goes here")
 }
 ```
 

--- a/writing-gleam/running-the-project.md
+++ b/writing-gleam/running-the-project.md
@@ -77,7 +77,7 @@ Running escriptize creates an executable file:
 
 An example main function signature would look like this:
 
-```gleam
+```rust
 import gleam/list
 
 pub external type CharList

--- a/writing-gleam/running-the-project.md
+++ b/writing-gleam/running-the-project.md
@@ -86,7 +86,7 @@ external fn char_list_to_string(CharList) -> String =
   "erlang" "list_to_binary"
 
 pub fn main(args_erlang: List(CharList)) {
-  args = args_erlang |> list.map(char_list_to_string)
+  let args = args_erlang |> list.map(char_list_to_string)
   
   ...
 }

--- a/writing-gleam/running-the-project.md
+++ b/writing-gleam/running-the-project.md
@@ -75,6 +75,23 @@ Running escriptize creates an executable file:
 
 `_build/default/bin/my_project_name` which requires a fn `main` as the entrypoint
 
+An example main function signature would look like this:
+
+```gleam
+import gleam/list
+
+pub external type CharList
+
+external fn char_list_to_string(CharList) -> String =
+  "erlang" "list_to_binary"
+
+pub fn main(args_erlang: List(CharList)) {
+  args = args_erlang |> list.map(char_list_to_string)
+  
+  ...
+}
+```
+
 ```sh
 # Build the project
 rebar3 compile


### PR DESCRIPTION
Update the documentation with an escript main function signature so that it's easier to work with arguments as strings rather than charlists. This took me entirely too long to figure out, hopefully it helps someone else.