### PR TITLE
Added gleam highlighting to highlight.js

### DIFF
--- a/book-src/tour/assert.md
+++ b/book-src/tour/assert.md
@@ -19,7 +19,7 @@ prototype application, so we want to only spend time on the success path for now
 For these situations Gleam provides `assert`, a keyword that causes the
 program to crash if a pattern does not match.
 
-```rust,noplaypen
+```gleam
 assert Ok(i) = parse_int("123")
 i // => 123
 ```
@@ -28,7 +28,7 @@ Here the `assert` keyword has been used to say "this function must return an
 `Ok` value" and we haven't had to write any error handling. The inner value
 is assigned the variable `i` and the program continues.
 
-```rust,noplaypen
+```gleam
 assert Ok(i) = parse_int("not an int")
 ```
 

--- a/book-src/tour/bit-strings.md
+++ b/book-src/tour/bit-strings.md
@@ -3,7 +3,7 @@
 Gleam offers a syntax for working directly with raw data in the form of bit
 strings.
 
-```rust,noplaypen
+```gleam
 // A bit string of the 8 bit int value 3
 <<3>>
 

--- a/book-src/tour/bools.md
+++ b/book-src/tour/bools.md
@@ -4,7 +4,7 @@ A Bool can be either `True` or `False`.
 
 Gleam defines a handful of operators that work with Bools.
 
-```rust,noplaypen
+```gleam
 False && False // => False
 False && True  // => False
 True && False  // => False
@@ -33,7 +33,7 @@ and Erlang's booleans.
 This is important if you want to use Gleam and Elixir or Erlang together in
 one project.
 
-```rust,noplaypen
+```gleam
 // Gleam
 True
 False

--- a/book-src/tour/case-expressions.md
+++ b/book-src/tour/case-expressions.md
@@ -8,7 +8,7 @@ Here we match on an `Int` and return a specific string for the values 0, 1,
 and 2. The final pattern `n` matches any other value that did not match any of
 the previous patterns.
 
-```rust,noplaypen
+```gleam
 case some_number {
   0 -> "Zero"
   1 -> "One"
@@ -20,7 +20,7 @@ case some_number {
 Pattern matching on a `Bool` value is the Gleam alternative to the `if else`
 statement found in other languages.
 
-```rust,noplaypen
+```gleam
 case some_bool {
   True -> "It's true!"
   False -> "It's not true."
@@ -31,7 +31,7 @@ Gleam's `case` is an expression, meaning it returns a value and can be used
 anywhere we would use a value. For example, we can name the value of a case
 expression with a `let` binding.
 
-```rust,noplaypen
+```gleam
 let description =
   case True {
     True -> "It's true!"
@@ -47,7 +47,7 @@ description  // => "It's true!"
 A `case` expression can be used to destructure values that
 contain other values, such as tuples and lists.
 
-```rust,noplaypen
+```gleam
 case xs {
   [] -> "This list is empty"
   [a] -> "This list has 1 element"
@@ -60,7 +60,7 @@ It's not just the top level data structure that can be pattern matches,
 contained values can also be matched. This gives `case` the ability to
 concisely express flow control that might be verbose without pattern matching.
 
-```rust,noplaypen
+```gleam
 case xs {
   [[]] -> "The only element is an empty list"
   [[], ..] -> "The 1st element is an empty list"
@@ -72,7 +72,7 @@ case xs {
 Pattern matching also works in `let` bindings, though patterns that do not
 match all instances of that type may result in a runtime error.
 
-```rust,noplaypen
+```gleam
 let [a] = [1]    // a is 1
 let [b] = [1, 2] // Runtime error! The pattern has 1 element but the value has 2
 ```
@@ -83,7 +83,7 @@ let [b] = [1, 2] // Runtime error! The pattern has 1 element but the value has 2
 Sometimes it is useful to pattern match on multiple values at the same time,
 so `case` supports having multiple subjects.
 
-```rust,noplaypen
+```gleam
 case x, y {
   1, 1 -> "both are 1"
   1, _ -> "x is 1"
@@ -98,7 +98,7 @@ case x, y {
 Sometimes when pattern matching we want to assign a name to a value while
 specifying its shape at the same time. We can do this using the `as` keyword.
 
-```rust,noplaypen
+```gleam
 case xs {
   [[_, ..] as inner_list] -> inner_list
   other -> []
@@ -113,14 +113,14 @@ the patterns have to match and the guard has to evaluate to `True` for the
 clause to match. The guard expression can check for equality or ordering for
 `Int` and `Float`.
 
-```rust,noplaypen
+```gleam
 case xs {
   [a, b, c] if a == b && b != c -> "ok"
   _other -> "ko"
 }
 ```
 
-```rust,noplaypen
+```gleam
 case xs {
   [a, b, c] if a >. b && a <=. c -> "ok"
   _other -> "ko"
@@ -135,7 +135,7 @@ any of the patterns match then the clause matches.
 
 Here the first clause will match if the variable `number` holds 2, 4, 6 or 8.
 
-```rust,noplaypen
+```gleam
 case number {
   2 | 4 | 6 | 8 -> "This is an even number"
   1 | 3 | 5 | 7 -> "This is an odd number"
@@ -147,7 +147,7 @@ If the patterns declare variables then the same variables must be declared in
 all patterns, and the variables must have the same type in all the patterns.
 
 
-```rust,noplaypen
+```gleam
 case list {
   [1, x] | x -> x // Error! Int != List(Int)
   _ -> 0

--- a/book-src/tour/comments.md
+++ b/book-src/tour/comments.md
@@ -4,7 +4,7 @@ Gleam allows you to write comments in your code.
 
 Here’s a simple comment:
 
-```rust,noplaypen
+```gleam
 // Hello, world!
 ```
 
@@ -12,7 +12,7 @@ In Gleam, comments must start with two slashes and continue until the end of the
 line. For comments that extend beyond a single line, you’ll need to include
 `//` on each line, like this:
 
-```rust,noplaypen
+```gleam
 // Hello, world! I have a lot to say, so much that it will take multiple
 // lines of text. Therefore, I will start each line with // to denote it
 // as part of a multi-line comment.
@@ -20,7 +20,7 @@ line. For comments that extend beyond a single line, you’ll need to include
 
 Comments can also be placed at the end of lines containing code:
 
-```rust,noplaypen
+```gleam
 pub fn add(x, y) {
   x + y // here we are adding two values together
 }
@@ -28,7 +28,7 @@ pub fn add(x, y) {
 
 Comments may also be indented:
 
-```rust,noplaypen
+```gleam
 pub fn multiply(x, y) {
   // here we are multiplying x by y
   x * y 

--- a/book-src/tour/constants.md
+++ b/book-src/tour/constants.md
@@ -3,7 +3,7 @@
 Gleam's module constants provide a way to use a certain fixed value in
 multiple places in a Gleam project.
 
-```rust,noplaypen
+```gleam
 pub const start_year = 2101
 pub const end_year = 2111
 
@@ -22,7 +22,7 @@ changed, so they cannot be used as global mutable state.
 When a constant is referenced the value is inlined by the compiler, so they
 can be used in case expression guards.
 
-```rust,noplaypen
+```gleam
 pub const start_year = 2101
 pub const end_year = 2111
 
@@ -39,7 +39,7 @@ pub describe(year: Int) -> String {
 
 Constants can also be given type annotations. 
 
-```rust,noplaypen
+```gleam
 pub const name: String = "Gleam"
 pub const size: Int = 100
 ```

--- a/book-src/tour/custom-types.md
+++ b/book-src/tour/custom-types.md
@@ -6,7 +6,7 @@ methods.
 
 Custom types are defined with the `type` keyword.
 
-```rust,noplaypen
+```gleam
 pub type Cat {
   Cat(name: String, cuteness: Int)
 }
@@ -20,7 +20,7 @@ The `pub` keyword makes this type usable from other modules.
 
 Once defined the custom type can be used in functions:
 
-```rust,noplaypen
+```gleam
 fn cats() {
   // Labelled fields can be given in any order
   let cat1 = Cat(name: "Nubi", cuteness: 2001)
@@ -44,7 +44,7 @@ We've already seen a custom type with multiple constructors in the Language Tour
 
 The built-in Gleam's `Bool` type is defined like this:
 
-```rust,noplaypen
+```gleam
 // A Bool is a value that is either `True` or `False`
 pub type Bool {
   True
@@ -61,13 +61,13 @@ different values. For example a `User` custom type could have a `LoggedIn`
 constructors that creates records with a name, and a `Guest` constructor which
 creates records without any contained values.
 
-```rust,noplaypen
+```gleam
 type User {
   LoggedIn(name: String)  // A logged in user with a name
   Guest                   // A guest user with no details
 }
 ```
-```rust,noplaypen
+```gleam
 let sara = LoggedIn(name: "Sara")
 let rick = LoggedIn(name: "Rick")
 let visitor = Guest
@@ -80,7 +80,7 @@ let visitor = Guest
 When given a custom type record we can pattern match on it to determine which
 record constructor matches, and to assign names to any contained values.
 
-```rust,noplaypen
+```gleam
 fn get_name(user) {
   case user {
     LoggedIn(name) -> name
@@ -91,12 +91,12 @@ fn get_name(user) {
 
 Custom types can also be destructured with a `let` binding.
 
-```rust,noplaypen
+```gleam
 type Score {
   Points(Int)
 }
 ```
-```rust,noplaypen
+```gleam
 let score = Points(50)
 let Points(p) = score
 
@@ -115,7 +115,7 @@ incremented. We don't want the user to alter the int value other than by
 incrementing it, so we can make the type opaque to prevent them from being
 able to do this.
 
-```rust,noplaypen
+```gleam
 // The type is defined with the opaque keyword
 pub opaque type Counter {
   Counter(value: Int)
@@ -142,7 +142,7 @@ type using the exported functions from the module, in this case `new` and
 Gleam provides a dedicated syntax for updating some of the fields of a custom
 type record.
 
-```rust,noplaypen
+```gleam
 pub type Person {
   Person(
     name: String,
@@ -175,7 +175,7 @@ Custom type records with contained values are Erlang records. The Gleam
 compiler generates an Erlang header file with a record definition for each
 constructor, for use from Erlang.
 
-```rust,noplaypen
+```gleam
 // Gleam
 Guest
 LoggedIn("Kim")

--- a/book-src/tour/expression-blocks.md
+++ b/book-src/tour/expression-blocks.md
@@ -3,7 +3,7 @@
 Every block in gleam is an expression. All expressions in the block are
 executed, and the result of the last expression is returned.
 
-```rust,noplaypen
+```gleam
 let value: Bool = {
     "Hello"
     42 + 12
@@ -14,6 +14,6 @@ let value: Bool = {
 Expression blocks can be used instead of parenthesis to change the precedence
 of operations.
 
-```rust,noplaypen
+```gleam
 let celsius = { fahrenheit - 32 } * 5 / 9
 ```

--- a/book-src/tour/external-functions.md
+++ b/book-src/tour/external-functions.md
@@ -24,7 +24,7 @@ prints it, and returns the same value.
 If we want to import these functions and use them in our program we would do
 so like this:
 
-```rust,noplaypen
+```gleam
 pub external fn random_float() -> Float = "rand" "uniform"
 
 // Elixir modules start with `Elixir.`
@@ -35,7 +35,7 @@ pub external fn inspect(a) -> a = "Elixir.IO" "inspect"
 
 Like regular functions, external functions can have labelled arguments.
 
-```rust,noplaypen
+```gleam
 pub external fn any(in: List(a), satisfying: fn(a) -> Bool) =
   "my_external_module" "any"
 ```
@@ -43,7 +43,7 @@ pub external fn any(in: List(a), satisfying: fn(a) -> Bool) =
 This function has the labelled arguments `in` and `satisfying`, and can be
 called like so:
 
-```rust,noplaypen
+```gleam
 any(in: my_list, satisfying: is_even)
 any(satisfying: is_even, in: my_list)
 ```

--- a/book-src/tour/external-types.md
+++ b/book-src/tour/external-types.md
@@ -8,7 +8,7 @@ functions that know how to work with them.
 Here is an example of importing a `Queue` data type and some functions from
 Erlang's `queue` module to work with the new `Queue` type.
 
-```rust,noplaypen
+```gleam
 pub external type Queue(a)
 
 pub external fn new() -> Queue(a) = "queue" "new"

--- a/book-src/tour/functions.md
+++ b/book-src/tour/functions.md
@@ -4,7 +4,7 @@
 
 Named functions in Gleam are defined using the `pub fn` keywords.
 
-```rust,noplaypen
+```gleam
 pub fn add(x: Int, y: Int) -> Int {
   x + y
 }
@@ -17,7 +17,7 @@ pub fn multiply(x: Int, y: Int) -> Int {
 Functions in Gleam are first class values and so can be assigned to variables,
 passed to functions, or anything else you might do with any other data type.
 
-```rust,noplaypen
+```gleam
 // This function takes a function as an argument
 pub fn twice(f: fn(t) -> t, x: t) -> t {
   f(f(x))
@@ -32,20 +32,19 @@ pub fn add_two(x: Int) -> Int {
 }
 ```
 
-
 ## Pipe Operator
 
 Gleam provides syntax for passing the result of one function to the arguments of another function, the pipe operator (`|>`). This is similar in functionality to the same operator in Elixir or F#.
 
 The pipe operator allows you to chain function calls without using a plethora of parenthesis. For a simple example, consider the following implementation of `string.reverse` in Gleam:
 
-```rust,noplaypen
+```gleam
 iodata.to_string(iodata.reverse(iodata.new(string)))
 ```
 
 This can be expressed more naturally using the pipe operator, eliminating the need to track parenthesis closure.
 
-```rust,noplaypen
+```gleam
 string
 |> iodata.new
 |> iodata.reverse
@@ -54,13 +53,12 @@ string
 
 Each line of this expression applies the function to the result of the previous line. This works easily because each of these functions take only one argument. Syntax is available to substitute specific arguments of functions that take more than one argument; for more, look below in the section "Function capturing".
 
-
 ## Type annotations
 
 Function arguments are normally annotated with their type, and the
 compiler will check these annotations and ensure they are correct.
 
-```rust,noplaypen
+```gleam
 fn identity(x: some_type) -> some_type {
   x
 }
@@ -76,7 +74,6 @@ best practice to always write type annotations for your functions as they
 provide useful documentation, and they encourage thinking about types as code
 is being written.
 
-
 ## Labelled arguments
 
 When functions take several arguments it can be difficult for the user to
@@ -87,7 +84,7 @@ arguments are given an external label in addition to their internal name.
 
 Take this function that replaces sections of a string:
 
-```rust,noplaypen
+```gleam
 pub fn replace(string: String, pattern: String, replacement: String) {
   // ...
 }
@@ -95,7 +92,7 @@ pub fn replace(string: String, pattern: String, replacement: String) {
 
 It can be given labels like so.
 
-```rust,noplaypen
+```gleam
 pub fn replace(
   in string: String,
   each pattern: String,
@@ -107,7 +104,7 @@ pub fn replace(
 
 These labels can then be used when calling the function.
 
-```rust,noplaypen
+```gleam
 replace(in: "A,B,C", each: ",", with: " ")
 
 // Labelled arguments can be given in any order
@@ -121,12 +118,11 @@ The use of argument labels can allow a function to be called in an expressive,
 sentence-like manner, while still providing a function body that is readable
 and clear in intent.
 
-
 ## Anonymous functions
 
 Anonymous functions can be defined with a similar syntax.
 
-```rust,noplaypen
+```gleam
 pub fn run() {
   let add = fn(x, y) { x + y }
 
@@ -140,7 +136,7 @@ There is a shorthand syntax for creating anonymous functions that take one
 argument and call another function. The `_` is used to indicate where the
 argument should be passed.
 
-```rust,noplaypen
+```gleam
 pub fn add(x, y) {
   x + y
 }
@@ -155,7 +151,7 @@ pub fn run() {
 The function capture syntax is often used with the pipe operator to create
 a series of transformations on some data.
 
-```rust,noplaypen
+```gleam
 pub fn add(x: Int , y: Int ) -> Int {
   x + y
 }
@@ -171,7 +167,7 @@ pub fn run() {
 
 In fact, this usage is so common that there is a special shorthand for it.
 
-```rust,noplaypen
+```gleam
 pub fn run() {
   // This is the same as the example above
   1

--- a/book-src/tour/ints-and-floats.md
+++ b/book-src/tour/ints-and-floats.md
@@ -7,7 +7,7 @@ Gleam's main number types are Int and Float.
 
 Ints are "whole" numbers.
 
-```rust,noplaypen
+```gleam
 1
 2
 -3
@@ -16,7 +16,7 @@ Ints are "whole" numbers.
 
 Gleam has several operators that work with Ints.
 
-```rust,noplaypen
+```gleam
 1 + 1 // => 2
 5 - 1 // => 4
 5 / 2 // => 2
@@ -31,7 +31,7 @@ Gleam has several operators that work with Ints.
 
 Underscores can be added to Ints for clarity.
 
-```rust,noplaypen
+```gleam
 1_000_000 // One million
 ```
 
@@ -39,7 +39,7 @@ Underscores can be added to Ints for clarity.
 
 Floats are numbers that have a decimal point.
 
-```rust,noplaypen
+```gleam
 1.5
 2.0
 -0.1
@@ -47,7 +47,7 @@ Floats are numbers that have a decimal point.
 
 Floats also have their own set of operators.
 
-```rust,noplaypen
+```gleam
 1.0 +. 1.4 // => 2.4
 5.0 -. 1.5 // => 3.5
 5.0 /. 2.0 // => 2.5
@@ -61,6 +61,6 @@ Floats also have their own set of operators.
 
 Underscores can also be added to Floats for clarity.
 
-```rust,noplaypen
+```gleam
 1_000_000.0 // One million
 ```

--- a/book-src/tour/let-bindings.md
+++ b/book-src/tour/let-bindings.md
@@ -4,7 +4,7 @@ A value can be given a name using `let`. Names can be reused by later let
 bindings, but the values contained are _immutable_, meaning the values
 themselves cannot be changed.
 
-```rust,noplaypen
+```gleam
 let x = 1
 let y = x
 let x = 2

--- a/book-src/tour/lists.md
+++ b/book-src/tour/lists.md
@@ -7,7 +7,7 @@ Lists are _homogeneous_, meaning all the elements of a List must be of the
 same type. Attempting to construct a list of multiple types of element will
 result in the compiler presenting a type error.
 
-```rust,noplaypen
+```gleam
 [1, 2, 3, 4]  // List(Int)
 [1.22, 2.30]  // List(Float)
 [1.22, 3, 4]  // Type error!
@@ -15,7 +15,7 @@ result in the compiler presenting a type error.
 
 Prepending to a list is very fast, and is the preferred way to add new values.
 
-```rust,noplaypen
+```gleam
 [1, ..[2, 3]]  // => [1, 2, 3]
 ```
 
@@ -23,7 +23,7 @@ Note that as all data structures in Gleam are immutable so prepending to a
 list does not change the original list, instead it efficiently creates a new
 list with the new additional element.
 
-```rust,noplaypen
+```gleam
 let x = [2, 3]
 let y = [1, ..x]
 

--- a/book-src/tour/modules.md
+++ b/book-src/tour/modules.md
@@ -4,7 +4,7 @@ Gleam programs are made up of bundles of functions and types called modules.
 Each module has its own namespace and can export types and values to be used
 by other modules in the program.
 
-```rust,noplaypen
+```gleam
 // inside src/nasa/rocket_ship.gleam
 
 fn count_down() {
@@ -38,7 +38,7 @@ called by other functions within the same module.
 To use functions or types from another module we need to import them using the
 `import` keyword.
 
-```rust,noplaypen
+```gleam
 // inside src/nasa/moon_base.gleam
 
 import nasa/rocket_ship
@@ -62,7 +62,7 @@ error as this function is private in the `rocket_ship` module.
 It is also possible to give a module a custom name when importing it using the
 `as` keyword.
 
-```rust,noplaypen
+```gleam
 import unix/cat
 import animal/cat as kitty
 ```
@@ -75,7 +75,7 @@ the same default name when imported.
 
 Values and types can also be imported in an unqualified fashion.
 
-```rust,noplaypen
+```gleam
 import animal/cat.{Cat, stroke}
 
 pub fn main() {

--- a/book-src/tour/result.md
+++ b/book-src/tour/result.md
@@ -1,6 +1,6 @@
 # `Result(value, error)`
 
-```rust,noplaypen
+```gleam
 pub type Result(value, reason) {
   Ok(value)
   Error(reason)
@@ -12,7 +12,7 @@ instead we have the `Result` type. If a function call fails, wrap the returned
 value in a `Result`, either `Ok` if the function was successful, or `Error`
 if it failed.
 
-```rust,noplaypen
+```gleam
 pub fn lookup(name, phone_book) {
   // ... we found a phone number in the phone book for the given name here
   Ok(phone_number)
@@ -22,7 +22,7 @@ pub fn lookup(name, phone_book) {
 The `Error` type needs to be given a reason for the failure in order to
 return, like so:
 
-```rust,noplaypen
+```gleam
 pub type MyDatabaseError {
   InvalidQuery
   NetworkTimeout
@@ -38,7 +38,7 @@ In cases where we don't care about the specific error enough to want to create
 a custom error type, or when the cause of the error is obvious without further
 detail, the `Nil` type can be used as the `Error` reason.
 
-```rust,noplaypen
+```gleam
 pub fn lookup(name, phone_book) {
   // ... That name wasn't found in the phone book
   Error(Nil)

--- a/book-src/tour/strings.md
+++ b/book-src/tour/strings.md
@@ -2,19 +2,19 @@
 
 Gleam's has UTF-8 binary strings, written as text surrounded by double quotes.
 
-```rust,noplaypen
+```gleam
 "Hello, Gleam!"
 ```
 
 Strings can span multiple lines.
 
-```rust,noplaypen
+```gleam
 "Hello
 Gleam!"
 ```
 
 Special characters such as `"` need to be escaped with a `\` character.
 
-```rust,noplaypen
+```gleam
 "Here is a double quote -> \" <-"
 ```

--- a/book-src/tour/todo.md
+++ b/book-src/tour/todo.md
@@ -5,7 +5,7 @@ Gleam's `todo` keyword is used to indicate that some code is not yet finished.
 It can be useful when designing a module, type checking functions and types
 but leaving the implementation of the functions until later.
 
-```rust,noplaypen
+```gleam
 fn favourite_number() -> Int {
   // The type annotations says this returns an Int, but we don't need
   // to implement it yet.
@@ -24,7 +24,7 @@ program if that function is run.
 A message can be given as a form of documentation. The message will be printed
 in the error message when the `todo` code is run.
 
-```rust,noplaypen
+```gleam
 fn favourite_number() -> Int {
   todo("We're going to decide which number is best tomorrow")
 }
@@ -38,7 +38,7 @@ replace the `todo`. This can be a useful way of asking the compiler what type
 is needed if you are ever unsure.
 
 
-```rust,noplaypen
+```gleam
 fn main() {
   my_complicated_function(
     // What type does this function take again...?

--- a/book-src/tour/try.md
+++ b/book-src/tour/try.md
@@ -4,7 +4,7 @@ In Gleam if a function can either succeed or fail then it normally will
 return the `Result` type. With `Result`, a successful return value is wrapped
 in an `Ok` record, and an error value is wrapped in an `Error` record.
 
-```rust,noplaypen
+```gleam
 // parse_int(String) -> Result(Int, String)
 
 parse_int("123") // -> Ok(123)
@@ -14,7 +14,7 @@ parse_int("erl") // -> Error("expected a number, got `erl`")
 When a function returns a `Result` we can pattern match on it to handle success
 and failure:
 
-```rust,noplaypen
+```gleam
 case parse_int("123") {
   Error(e) -> io.println("That wasn't an Int")
   Ok(i) -> io.println("We parsed the Int")
@@ -24,7 +24,7 @@ case parse_int("123") {
 This is such a common pattern in Gleam that the `try` syntax exists to make it
 more consise.
 
-```rust,noplaypen
+```gleam
 try int_a = parse_int(a)
 try int_b = parse_int(b)
 try int_c = parse_int(c)
@@ -35,14 +35,14 @@ When a variable is declared using `try` Gleam checks to see whether the value
 is an Error or an Ok record. If it's an Ok then the inner value is assigned to
 the variable:
 
-```rust,noplaypen
+```gleam
 try x = Ok(1)
 Ok(x + 1)
 // -> Ok(2)
 ```
 If it's an Error then the Error is returned immediately:
 
-```rust,noplaypen
+```gleam
 try x = Error("failure")
 Ok(x + 1)
 // -> Error("failure")

--- a/book-src/tour/tuples.md
+++ b/book-src/tour/tuples.md
@@ -4,7 +4,7 @@ Lists are good for when we want a collection of one type, but sometime we want
 to combine multiple values of different types. In this case tuples are a quick
 and convenient option.
 
-```rust,noplaypen
+```gleam
 fn run() {
   tuple(10, "hello") // Type is tuple(Int, String)
   tuple(1, 4.2, [0]) // Type is tuple(Int, Float, List(Int))

--- a/book-src/tour/type-aliases.md
+++ b/book-src/tour/type-aliases.md
@@ -7,7 +7,7 @@ Here we are giving the type `List(tuple(String, String))` the new name
 `Headers`. This may be useful in a web application where we want to write
 multiple functions that return headers.
 
-```rust,noplaypen
+```gleam
 pub type Headers =
   List(tuple(String, String))
 ```

--- a/book.toml
+++ b/book.toml
@@ -3,3 +3,6 @@ authors = ["Louis Pilfold"]
 multilingual = false
 src = "book-src"
 title = "The Gleam Book"
+
+[output.html]
+additional-js = ["javascript/highlightjs-gleam.js"]

--- a/book/404.html
+++ b/book/404.html
@@ -215,6 +215,8 @@
 
         <!-- Custom JS scripts -->
         
+        <script type="text/javascript" src="javascript/highlightjs-gleam.js"></script>
+        
 
         
 

--- a/book/index.html
+++ b/book/index.html
@@ -228,6 +228,8 @@ information can be safely ignored.</p>
 
         <!-- Custom JS scripts -->
         
+        <script type="text/javascript" src="javascript/highlightjs-gleam.js"></script>
+        
 
         
 

--- a/book/javascript/highlightjs-gleam.js
+++ b/book/javascript/highlightjs-gleam.js
@@ -1,0 +1,105 @@
+hljs.registerLanguage("gleam", function (hljs) {
+  const KEYWORDS =
+    "as assert case const external fn if import let " +
+    "opaque pub todo try tuple type";
+  const STRING = {
+    className: "string",
+    variants: [{ begin: /"/, end: /"/ }],
+    contains: [hljs.BACKSLASH_ESCAPE],
+    relevance: 0,
+  };
+  const NAME = {
+    className: "variable",
+    begin: "\\b[a-z][a-z0-9_]*\\b",
+    relevance: 0,
+  };
+  const DISCARD_NAME = {
+    className: "comment",
+    begin: "\\b_[a-z][a-z0-9_]*\\b",
+    relevance: 0,
+  };
+  const NUMBER = {
+    className: "number",
+    variants: [
+      {
+        begin: "\\b0b([01_]+)",
+      },
+      {
+        begin: "\\b0o([0-7_]+)",
+      },
+      {
+        begin: "\\b0x([A-Fa-f0-9_]+)",
+      },
+      {
+        begin: "\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)",
+      },
+    ],
+    relevance: 0,
+  };
+
+  return {
+    name: "Gleam",
+    aliases: ["gleam"],
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      STRING,
+      {
+        // bitstrings
+        begin: "<<",
+        end: ">>",
+        contains: [
+          {
+            className: "keyword",
+            beginKeywords:
+              "binary bytes int float bit_string bits utf8 utf16 utf32 " +
+              "utf8_codepoint utf16_codepoint utf32_codepoint signed unsigned " +
+              "big little native unit size",
+          },
+          STRING,
+          NUMBER,
+          NAME,
+          DISCARD_NAME,
+        ],
+        relevance: 10,
+      },
+      {
+        className: "function",
+        beginKeywords: "fn",
+        end: "\\(",
+        excludeEnd: true,
+        contains: [
+          {
+            className: "title",
+            begin: "[a-zA-Z0-9_]\\w*",
+            relevance: 0,
+          },
+        ],
+      },
+      {
+        className: "keyword",
+        beginKeywords: KEYWORDS,
+      },
+      {
+        // Type names and constructors
+        className: "title",
+        begin: "\\b[A-Z][A-Za-z0-9_]*\\b",
+        relevance: 0,
+      },
+      {
+        // float operators
+        className: "operator",
+        begin: "(\\+\\.|-\\.|\\*\\.|/\\.|<\\.|>\\.)",
+        relevance: 10,
+      },
+      {
+        className: "operator",
+        begin: "(->|\\|>|<<|>>|\\+|-|\\*|/|>=|<=|<|<|%|\\.\\.|\\|=|==|!=)",
+        relevance: 0,
+      },
+      NUMBER,
+      NAME,
+      DISCARD_NAME,
+    ],
+  };
+});
+hljs.initHighlightingOnLoad();

--- a/book/print.html
+++ b/book/print.html
@@ -177,41 +177,41 @@ information can be safely ignored.</p>
 <h1><a class="header" href="#comments" id="comments">Comments</a></h1>
 <p>Gleam allows you to write comments in your code.</p>
 <p>Here’s a simple comment:</p>
-<pre><code class="language-rust noplaypen">// Hello, world!
+<pre><code class="language-gleam">// Hello, world!
 </code></pre>
 <p>In Gleam, comments must start with two slashes and continue until the end of the
 line. For comments that extend beyond a single line, you’ll need to include
 <code>//</code> on each line, like this:</p>
-<pre><code class="language-rust noplaypen">// Hello, world! I have a lot to say, so much that it will take multiple
+<pre><code class="language-gleam">// Hello, world! I have a lot to say, so much that it will take multiple
 // lines of text. Therefore, I will start each line with // to denote it
 // as part of a multi-line comment.
 </code></pre>
 <p>Comments can also be placed at the end of lines containing code:</p>
-<pre><code class="language-rust noplaypen">pub fn add(x, y) {
+<pre><code class="language-gleam">pub fn add(x, y) {
   x + y // here we are adding two values together
 }
 </code></pre>
 <p>Comments may also be indented:</p>
-<pre><code class="language-rust noplaypen">pub fn multiply(x, y) {
+<pre><code class="language-gleam">pub fn multiply(x, y) {
   // here we are multiplying x by y
   x * y 
 }
 </code></pre>
 <h1><a class="header" href="#string" id="string">String</a></h1>
 <p>Gleam's has UTF-8 binary strings, written as text surrounded by double quotes.</p>
-<pre><code class="language-rust noplaypen">&quot;Hello, Gleam!&quot;
+<pre><code class="language-gleam">&quot;Hello, Gleam!&quot;
 </code></pre>
 <p>Strings can span multiple lines.</p>
-<pre><code class="language-rust noplaypen">&quot;Hello
+<pre><code class="language-gleam">&quot;Hello
 Gleam!&quot;
 </code></pre>
 <p>Special characters such as <code>&quot;</code> need to be escaped with a <code>\</code> character.</p>
-<pre><code class="language-rust noplaypen">&quot;Here is a double quote -&gt; \&quot; &lt;-&quot;
+<pre><code class="language-gleam">&quot;Here is a double quote -&gt; \&quot; &lt;-&quot;
 </code></pre>
 <h1><a class="header" href="#bool" id="bool">Bool</a></h1>
 <p>A Bool can be either <code>True</code> or <code>False</code>.</p>
 <p>Gleam defines a handful of operators that work with Bools.</p>
-<pre><code class="language-rust noplaypen">False &amp;&amp; False // =&gt; False
+<pre><code class="language-gleam">False &amp;&amp; False // =&gt; False
 False &amp;&amp; True  // =&gt; False
 True &amp;&amp; False  // =&gt; False
 True &amp;&amp; True   // =&gt; True
@@ -231,7 +231,7 @@ runtime with the atoms <code>true</code> and <code>false</code>, making them com
 and Erlang's booleans.</p>
 <p>This is important if you want to use Gleam and Elixir or Erlang together in
 one project.</p>
-<pre><code class="language-rust noplaypen">// Gleam
+<pre><code class="language-gleam">// Gleam
 True
 False
 </code></pre>
@@ -243,13 +243,13 @@ false.
 <p>Gleam's main number types are Int and Float.</p>
 <h2><a class="header" href="#ints" id="ints">Ints</a></h2>
 <p>Ints are &quot;whole&quot; numbers.</p>
-<pre><code class="language-rust noplaypen">1
+<pre><code class="language-gleam">1
 2
 -3
 4001
 </code></pre>
 <p>Gleam has several operators that work with Ints.</p>
-<pre><code class="language-rust noplaypen">1 + 1 // =&gt; 2
+<pre><code class="language-gleam">1 + 1 // =&gt; 2
 5 - 1 // =&gt; 4
 5 / 2 // =&gt; 2
 3 * 3 // =&gt; 9
@@ -261,16 +261,16 @@ false.
 2 &lt;= 1 // =&gt; False
 </code></pre>
 <p>Underscores can be added to Ints for clarity.</p>
-<pre><code class="language-rust noplaypen">1_000_000 // One million
+<pre><code class="language-gleam">1_000_000 // One million
 </code></pre>
 <h2><a class="header" href="#floats" id="floats">Floats</a></h2>
 <p>Floats are numbers that have a decimal point.</p>
-<pre><code class="language-rust noplaypen">1.5
+<pre><code class="language-gleam">1.5
 2.0
 -0.1
 </code></pre>
 <p>Floats also have their own set of operators.</p>
-<pre><code class="language-rust noplaypen">1.0 +. 1.4 // =&gt; 2.4
+<pre><code class="language-gleam">1.0 +. 1.4 // =&gt; 2.4
 5.0 -. 1.5 // =&gt; 3.5
 5.0 /. 2.0 // =&gt; 2.5
 3.0 *. 3.1 // =&gt; 9.3
@@ -281,13 +281,13 @@ false.
 2.0 &lt;=. 1.0 // =&gt; False
 </code></pre>
 <p>Underscores can also be added to Floats for clarity.</p>
-<pre><code class="language-rust noplaypen">1_000_000.0 // One million
+<pre><code class="language-gleam">1_000_000.0 // One million
 </code></pre>
 <h1><a class="header" href="#let-bindings" id="let-bindings">Let bindings</a></h1>
 <p>A value can be given a name using <code>let</code>. Names can be reused by later let
 bindings, but the values contained are <em>immutable</em>, meaning the values
 themselves cannot be changed.</p>
-<pre><code class="language-rust noplaypen">let x = 1
+<pre><code class="language-gleam">let x = 1
 let y = x
 let x = 2
 
@@ -297,7 +297,7 @@ y  // =&gt; 1
 <h1><a class="header" href="#expression-blocks" id="expression-blocks">Expression blocks</a></h1>
 <p>Every block in gleam is an expression. All expressions in the block are
 executed, and the result of the last expression is returned.</p>
-<pre><code class="language-rust noplaypen">let value: Bool = {
+<pre><code class="language-gleam">let value: Bool = {
     &quot;Hello&quot;
     42 + 12
     False
@@ -305,7 +305,7 @@ executed, and the result of the last expression is returned.</p>
 </code></pre>
 <p>Expression blocks can be used instead of parenthesis to change the precedence
 of operations.</p>
-<pre><code class="language-rust noplaypen">let celsius = { fahrenheit - 32 } * 5 / 9
+<pre><code class="language-gleam">let celsius = { fahrenheit - 32 } * 5 / 9
 </code></pre>
 <h1><a class="header" href="#list" id="list">List</a></h1>
 <p>Lists are ordered collections of values. They're one of the most common data
@@ -313,17 +313,17 @@ structures in Gleam.</p>
 <p>Lists are <em>homogeneous</em>, meaning all the elements of a List must be of the
 same type. Attempting to construct a list of multiple types of element will
 result in the compiler presenting a type error.</p>
-<pre><code class="language-rust noplaypen">[1, 2, 3, 4]  // List(Int)
+<pre><code class="language-gleam">[1, 2, 3, 4]  // List(Int)
 [1.22, 2.30]  // List(Float)
 [1.22, 3, 4]  // Type error!
 </code></pre>
 <p>Prepending to a list is very fast, and is the preferred way to add new values.</p>
-<pre><code class="language-rust noplaypen">[1, ..[2, 3]]  // =&gt; [1, 2, 3]
+<pre><code class="language-gleam">[1, ..[2, 3]]  // =&gt; [1, 2, 3]
 </code></pre>
 <p>Note that as all data structures in Gleam are immutable so prepending to a
 list does not change the original list, instead it efficiently creates a new
 list with the new additional element.</p>
-<pre><code class="language-rust noplaypen">let x = [2, 3]
+<pre><code class="language-gleam">let x = [2, 3]
 let y = [1, ..x]
 
 
@@ -334,7 +334,7 @@ y  // =&gt; [1, 2, 3]
 <p>Lists are good for when we want a collection of one type, but sometime we want
 to combine multiple values of different types. In this case tuples are a quick
 and convenient option.</p>
-<pre><code class="language-rust noplaypen">fn run() {
+<pre><code class="language-gleam">fn run() {
   tuple(10, &quot;hello&quot;) // Type is tuple(Int, String)
   tuple(1, 4.2, [0]) // Type is tuple(Int, Float, List(Int))
 }
@@ -346,7 +346,7 @@ allows us to say &quot;if the data has this shape then do that&quot;, which we c
 <p>Here we match on an <code>Int</code> and return a specific string for the values 0, 1,
 and 2. The final pattern <code>n</code> matches any other value that did not match any of
 the previous patterns.</p>
-<pre><code class="language-rust noplaypen">case some_number {
+<pre><code class="language-gleam">case some_number {
   0 -&gt; &quot;Zero&quot;
   1 -&gt; &quot;One&quot;
   2 -&gt; &quot;Two&quot;
@@ -355,7 +355,7 @@ the previous patterns.</p>
 </code></pre>
 <p>Pattern matching on a <code>Bool</code> value is the Gleam alternative to the <code>if else</code>
 statement found in other languages.</p>
-<pre><code class="language-rust noplaypen">case some_bool {
+<pre><code class="language-gleam">case some_bool {
   True -&gt; &quot;It's true!&quot;
   False -&gt; &quot;It's not true.&quot;
 }
@@ -363,7 +363,7 @@ statement found in other languages.</p>
 <p>Gleam's <code>case</code> is an expression, meaning it returns a value and can be used
 anywhere we would use a value. For example, we can name the value of a case
 expression with a <code>let</code> binding.</p>
-<pre><code class="language-rust noplaypen">let description =
+<pre><code class="language-gleam">let description =
   case True {
     True -&gt; &quot;It's true!&quot;
     False -&gt; &quot;It's not true.&quot;
@@ -374,7 +374,7 @@ description  // =&gt; &quot;It's true!&quot;
 <h2><a class="header" href="#destructuring" id="destructuring">Destructuring</a></h2>
 <p>A <code>case</code> expression can be used to destructure values that
 contain other values, such as tuples and lists.</p>
-<pre><code class="language-rust noplaypen">case xs {
+<pre><code class="language-gleam">case xs {
   [] -&gt; &quot;This list is empty&quot;
   [a] -&gt; &quot;This list has 1 element&quot;
   [a, b] -&gt; &quot;This list has 2 elements&quot;
@@ -384,7 +384,7 @@ contain other values, such as tuples and lists.</p>
 <p>It's not just the top level data structure that can be pattern matches,
 contained values can also be matched. This gives <code>case</code> the ability to
 concisely express flow control that might be verbose without pattern matching.</p>
-<pre><code class="language-rust noplaypen">case xs {
+<pre><code class="language-gleam">case xs {
   [[]] -&gt; &quot;The only element is an empty list&quot;
   [[], ..] -&gt; &quot;The 1st element is an empty list&quot;
   [[4], ..] -&gt; &quot;The 1st element is a list of the number 4&quot;
@@ -393,13 +393,13 @@ concisely express flow control that might be verbose without pattern matching.</
 </code></pre>
 <p>Pattern matching also works in <code>let</code> bindings, though patterns that do not
 match all instances of that type may result in a runtime error.</p>
-<pre><code class="language-rust noplaypen">let [a] = [1]    // a is 1
+<pre><code class="language-gleam">let [a] = [1]    // a is 1
 let [b] = [1, 2] // Runtime error! The pattern has 1 element but the value has 2
 </code></pre>
 <h2><a class="header" href="#matching-on-multiple-values" id="matching-on-multiple-values">Matching on multiple values</a></h2>
 <p>Sometimes it is useful to pattern match on multiple values at the same time,
 so <code>case</code> supports having multiple subjects.</p>
-<pre><code class="language-rust noplaypen">case x, y {
+<pre><code class="language-gleam">case x, y {
   1, 1 -&gt; &quot;both are 1&quot;
   1, _ -&gt; &quot;x is 1&quot;
   _, 1 -&gt; &quot;y is 1&quot;
@@ -409,7 +409,7 @@ so <code>case</code> supports having multiple subjects.</p>
 <h2><a class="header" href="#assigning-names-to-sub-patterns" id="assigning-names-to-sub-patterns">Assigning names to sub-patterns</a></h2>
 <p>Sometimes when pattern matching we want to assign a name to a value while
 specifying its shape at the same time. We can do this using the <code>as</code> keyword.</p>
-<pre><code class="language-rust noplaypen">case xs {
+<pre><code class="language-gleam">case xs {
   [[_, ..] as inner_list] -&gt; inner_list
   other -&gt; []
 }
@@ -419,12 +419,12 @@ specifying its shape at the same time. We can do this using the <code>as</code> 
 the patterns have to match and the guard has to evaluate to <code>True</code> for the
 clause to match. The guard expression can check for equality or ordering for
 <code>Int</code> and <code>Float</code>.</p>
-<pre><code class="language-rust noplaypen">case xs {
+<pre><code class="language-gleam">case xs {
   [a, b, c] if a == b &amp;&amp; b != c -&gt; &quot;ok&quot;
   _other -&gt; &quot;ko&quot;
 }
 </code></pre>
-<pre><code class="language-rust noplaypen">case xs {
+<pre><code class="language-gleam">case xs {
   [a, b, c] if a &gt;. b &amp;&amp; a &lt;=. c -&gt; &quot;ok&quot;
   _other -&gt; &quot;ko&quot;
 }
@@ -433,7 +433,7 @@ clause to match. The guard expression can check for equality or ordering for
 <p>Alternative patterns can be given for a case clause using the <code>|</code> operator. If
 any of the patterns match then the clause matches.</p>
 <p>Here the first clause will match if the variable <code>number</code> holds 2, 4, 6 or 8.</p>
-<pre><code class="language-rust noplaypen">case number {
+<pre><code class="language-gleam">case number {
   2 | 4 | 6 | 8 -&gt; &quot;This is an even number&quot;
   1 | 3 | 5 | 7 -&gt; &quot;This is an odd number&quot;
   _ -&gt; &quot;I'm not sure&quot;
@@ -441,7 +441,7 @@ any of the patterns match then the clause matches.</p>
 </code></pre>
 <p>If the patterns declare variables then the same variables must be declared in
 all patterns, and the variables must have the same type in all the patterns.</p>
-<pre><code class="language-rust noplaypen">case list {
+<pre><code class="language-gleam">case list {
   [1, x] | x -&gt; x // Error! Int != List(Int)
   _ -&gt; 0
 }
@@ -449,7 +449,7 @@ all patterns, and the variables must have the same type in all the patterns.</p>
 <h1><a class="header" href="#function" id="function">Function</a></h1>
 <h2><a class="header" href="#named-functions" id="named-functions">Named functions</a></h2>
 <p>Named functions in Gleam are defined using the <code>pub fn</code> keywords.</p>
-<pre><code class="language-rust noplaypen">pub fn add(x: Int, y: Int) -&gt; Int {
+<pre><code class="language-gleam">pub fn add(x: Int, y: Int) -&gt; Int {
   x + y
 }
 
@@ -459,7 +459,7 @@ pub fn multiply(x: Int, y: Int) -&gt; Int {
 </code></pre>
 <p>Functions in Gleam are first class values and so can be assigned to variables,
 passed to functions, or anything else you might do with any other data type.</p>
-<pre><code class="language-rust noplaypen">// This function takes a function as an argument
+<pre><code class="language-gleam">// This function takes a function as an argument
 pub fn twice(f: fn(t) -&gt; t, x: t) -&gt; t {
   f(f(x))
 }
@@ -475,10 +475,10 @@ pub fn add_two(x: Int) -&gt; Int {
 <h2><a class="header" href="#pipe-operator" id="pipe-operator">Pipe Operator</a></h2>
 <p>Gleam provides syntax for passing the result of one function to the arguments of another function, the pipe operator (<code>|&gt;</code>). This is similar in functionality to the same operator in Elixir or F#.</p>
 <p>The pipe operator allows you to chain function calls without using a plethora of parenthesis. For a simple example, consider the following implementation of <code>string.reverse</code> in Gleam:</p>
-<pre><code class="language-rust noplaypen">iodata.to_string(iodata.reverse(iodata.new(string)))
+<pre><code class="language-gleam">iodata.to_string(iodata.reverse(iodata.new(string)))
 </code></pre>
 <p>This can be expressed more naturally using the pipe operator, eliminating the need to track parenthesis closure.</p>
-<pre><code class="language-rust noplaypen">string
+<pre><code class="language-gleam">string
 |&gt; iodata.new
 |&gt; iodata.reverse
 |&gt; iodata.to_string
@@ -487,7 +487,7 @@ pub fn add_two(x: Int) -&gt; Int {
 <h2><a class="header" href="#type-annotations" id="type-annotations">Type annotations</a></h2>
 <p>Function arguments are normally annotated with their type, and the
 compiler will check these annotations and ensure they are correct.</p>
-<pre><code class="language-rust noplaypen">fn identity(x: some_type) -&gt; some_type {
+<pre><code class="language-gleam">fn identity(x: some_type) -&gt; some_type {
   x
 }
 
@@ -506,12 +506,12 @@ remember what the arguments are, and what order they are expected in.</p>
 <p>To help with this Gleam supports <em>labelled arguments</em>, where function
 arguments are given an external label in addition to their internal name.</p>
 <p>Take this function that replaces sections of a string:</p>
-<pre><code class="language-rust noplaypen">pub fn replace(string: String, pattern: String, replacement: String) {
+<pre><code class="language-gleam">pub fn replace(string: String, pattern: String, replacement: String) {
   // ...
 }
 </code></pre>
 <p>It can be given labels like so.</p>
-<pre><code class="language-rust noplaypen">pub fn replace(
+<pre><code class="language-gleam">pub fn replace(
   in string: String,
   each pattern: String,
   with replacement: String,
@@ -520,7 +520,7 @@ arguments are given an external label in addition to their internal name.</p>
 }
 </code></pre>
 <p>These labels can then be used when calling the function.</p>
-<pre><code class="language-rust noplaypen">replace(in: &quot;A,B,C&quot;, each: &quot;,&quot;, with: &quot; &quot;)
+<pre><code class="language-gleam">replace(in: &quot;A,B,C&quot;, each: &quot;,&quot;, with: &quot; &quot;)
 
 // Labelled arguments can be given in any order
 replace(each: &quot;,&quot;, with: &quot; &quot;, in: &quot;A,B,C&quot;)
@@ -533,7 +533,7 @@ sentence-like manner, while still providing a function body that is readable
 and clear in intent.</p>
 <h2><a class="header" href="#anonymous-functions" id="anonymous-functions">Anonymous functions</a></h2>
 <p>Anonymous functions can be defined with a similar syntax.</p>
-<pre><code class="language-rust noplaypen">pub fn run() {
+<pre><code class="language-gleam">pub fn run() {
   let add = fn(x, y) { x + y }
 
   add(1, 2)
@@ -543,7 +543,7 @@ and clear in intent.</p>
 <p>There is a shorthand syntax for creating anonymous functions that take one
 argument and call another function. The <code>_</code> is used to indicate where the
 argument should be passed.</p>
-<pre><code class="language-rust noplaypen">pub fn add(x, y) {
+<pre><code class="language-gleam">pub fn add(x, y) {
   x + y
 }
 
@@ -555,7 +555,7 @@ pub fn run() {
 </code></pre>
 <p>The function capture syntax is often used with the pipe operator to create
 a series of transformations on some data.</p>
-<pre><code class="language-rust noplaypen">pub fn add(x: Int , y: Int ) -&gt; Int {
+<pre><code class="language-gleam">pub fn add(x: Int , y: Int ) -&gt; Int {
   x + y
 }
 
@@ -568,7 +568,7 @@ pub fn run() {
 }
 </code></pre>
 <p>In fact, this usage is so common that there is a special shorthand for it.</p>
-<pre><code class="language-rust noplaypen">pub fn run() {
+<pre><code class="language-gleam">pub fn run() {
   // This is the same as the example above
   1
   |&gt; add(3)
@@ -584,7 +584,7 @@ as the first argument to the call, e.g. <code>a |&gt; b(1, 2)</code> would becom
 <p>Gleam programs are made up of bundles of functions and types called modules.
 Each module has its own namespace and can export types and values to be used
 by other modules in the program.</p>
-<pre><code class="language-rust noplaypen">// inside src/nasa/rocket_ship.gleam
+<pre><code class="language-gleam">// inside src/nasa/rocket_ship.gleam
 
 fn count_down() {
   &quot;3... 2... 1...&quot;
@@ -611,7 +611,7 @@ called by other functions within the same module.</p>
 <h2><a class="header" href="#import" id="import">Import</a></h2>
 <p>To use functions or types from another module we need to import them using the
 <code>import</code> keyword.</p>
-<pre><code class="language-rust noplaypen">// inside src/nasa/moon_base.gleam
+<pre><code class="language-gleam">// inside src/nasa/moon_base.gleam
 
 import nasa/rocket_ship
 
@@ -628,14 +628,14 @@ error as this function is private in the <code>rocket_ship</code> module.</p>
 <h2><a class="header" href="#named-import" id="named-import">Named import</a></h2>
 <p>It is also possible to give a module a custom name when importing it using the
 <code>as</code> keyword.</p>
-<pre><code class="language-rust noplaypen">import unix/cat
+<pre><code class="language-gleam">import unix/cat
 import animal/cat as kitty
 </code></pre>
 <p>This may be useful to differentiate between multiple modules that would have
 the same default name when imported.</p>
 <h2><a class="header" href="#unqualified-import" id="unqualified-import">Unqualified import</a></h2>
 <p>Values and types can also be imported in an unqualified fashion.</p>
-<pre><code class="language-rust noplaypen">import animal/cat.{Cat, stroke}
+<pre><code class="language-gleam">import animal/cat.{Cat, stroke}
 
 pub fn main() {
   let kitty = Cat(name: &quot;Nubi&quot;)
@@ -650,7 +650,7 @@ value is defined.</p>
 similar to objects in object oriented languages, though they don't have
 methods.</p>
 <p>Custom types are defined with the <code>type</code> keyword.</p>
-<pre><code class="language-rust noplaypen">pub type Cat {
+<pre><code class="language-gleam">pub type Cat {
   Cat(name: String, cuteness: Int)
 }
 </code></pre>
@@ -659,7 +659,7 @@ methods.</p>
 <code>cuteness</code> field which is an <code>Int</code>.</p>
 <p>The <code>pub</code> keyword makes this type usable from other modules.</p>
 <p>Once defined the custom type can be used in functions:</p>
-<pre><code class="language-rust noplaypen">fn cats() {
+<pre><code class="language-gleam">fn cats() {
   // Labelled fields can be given in any order
   let cat1 = Cat(name: &quot;Nubi&quot;, cuteness: 2001)
   let cat2 = Cat(cuteness: 1805, name: &quot;Biffy&quot;)
@@ -678,7 +678,7 @@ way of modeling data that can be one of a few different variants.</p>
 <li><a href="tour/./bools.html"><code>Bool</code></a>.</li>
 </ul>
 <p>The built-in Gleam's <code>Bool</code> type is defined like this:</p>
-<pre><code class="language-rust noplaypen">// A Bool is a value that is either `True` or `False`
+<pre><code class="language-gleam">// A Bool is a value that is either `True` or `False`
 pub type Bool {
   True
   False
@@ -691,19 +691,19 @@ or <code>False</code>.</p>
 different values. For example a <code>User</code> custom type could have a <code>LoggedIn</code>
 constructors that creates records with a name, and a <code>Guest</code> constructor which
 creates records without any contained values.</p>
-<pre><code class="language-rust noplaypen">type User {
+<pre><code class="language-gleam">type User {
   LoggedIn(name: String)  // A logged in user with a name
   Guest                   // A guest user with no details
 }
 </code></pre>
-<pre><code class="language-rust noplaypen">let sara = LoggedIn(name: &quot;Sara&quot;)
+<pre><code class="language-gleam">let sara = LoggedIn(name: &quot;Sara&quot;)
 let rick = LoggedIn(name: &quot;Rick&quot;)
 let visitor = Guest
 </code></pre>
 <h2><a class="header" href="#destructuring-1" id="destructuring-1">Destructuring</a></h2>
 <p>When given a custom type record we can pattern match on it to determine which
 record constructor matches, and to assign names to any contained values.</p>
-<pre><code class="language-rust noplaypen">fn get_name(user) {
+<pre><code class="language-gleam">fn get_name(user) {
   case user {
     LoggedIn(name) -&gt; name
     Guest -&gt; &quot;Guest user&quot;
@@ -711,11 +711,11 @@ record constructor matches, and to assign names to any contained values.</p>
 }
 </code></pre>
 <p>Custom types can also be destructured with a <code>let</code> binding.</p>
-<pre><code class="language-rust noplaypen">type Score {
+<pre><code class="language-gleam">type Score {
   Points(Int)
 }
 </code></pre>
-<pre><code class="language-rust noplaypen">let score = Points(50)
+<pre><code class="language-gleam">let score = Points(50)
 let Points(p) = score
 
 p // =&gt; 50
@@ -728,7 +728,7 @@ publically exported functions.</p>
 incremented. We don't want the user to alter the int value other than by
 incrementing it, so we can make the type opaque to prevent them from being
 able to do this.</p>
-<pre><code class="language-rust noplaypen">// The type is defined with the opaque keyword
+<pre><code class="language-gleam">// The type is defined with the opaque keyword
 pub opaque type Counter {
   Counter(value: Int)
 }
@@ -749,7 +749,7 @@ type using the exported functions from the module, in this case <code>new</code>
 <h2><a class="header" href="#record-updates" id="record-updates">Record updates</a></h2>
 <p>Gleam provides a dedicated syntax for updating some of the fields of a custom
 type record.</p>
-<pre><code class="language-rust noplaypen">pub type Person {
+<pre><code class="language-gleam">pub type Person {
   Person(
     name: String,
     gender: Option(String),
@@ -775,7 +775,7 @@ becomes <code>logged_in</code>.</p>
 <p>Custom type records with contained values are Erlang records. The Gleam
 compiler generates an Erlang header file with a record definition for each
 constructor, for use from Erlang.</p>
-<pre><code class="language-rust noplaypen">// Gleam
+<pre><code class="language-gleam">// Gleam
 Guest
 LoggedIn(&quot;Kim&quot;)
 </code></pre>
@@ -788,7 +788,7 @@ guest,
 {logged_in, &lt;&lt;&quot;Kim&quot;&gt;&gt;}.
 </code></pre>
 <h1><a class="header" href="#resultvalue-error" id="resultvalue-error"><code>Result(value, error)</code></a></h1>
-<pre><code class="language-rust noplaypen">pub type Result(value, reason) {
+<pre><code class="language-gleam">pub type Result(value, reason) {
   Ok(value)
   Error(reason)
 }
@@ -797,14 +797,14 @@ guest,
 instead we have the <code>Result</code> type. If a function call fails, wrap the returned
 value in a <code>Result</code>, either <code>Ok</code> if the function was successful, or <code>Error</code>
 if it failed.</p>
-<pre><code class="language-rust noplaypen">pub fn lookup(name, phone_book) {
+<pre><code class="language-gleam">pub fn lookup(name, phone_book) {
   // ... we found a phone number in the phone book for the given name here
   Ok(phone_number)
 }
 </code></pre>
 <p>The <code>Error</code> type needs to be given a reason for the failure in order to
 return, like so:</p>
-<pre><code class="language-rust noplaypen">pub type MyDatabaseError {
+<pre><code class="language-gleam">pub type MyDatabaseError {
   InvalidQuery
   NetworkTimeout
 }
@@ -817,7 +817,7 @@ pub fn insert(db_row) {
 <p>In cases where we don't care about the specific error enough to want to create
 a custom error type, or when the cause of the error is obvious without further
 detail, the <code>Nil</code> type can be used as the <code>Error</code> reason.</p>
-<pre><code class="language-rust noplaypen">pub fn lookup(name, phone_book) {
+<pre><code class="language-gleam">pub fn lookup(name, phone_book) {
   // ... That name wasn't found in the phone book
   Error(Nil)
 }
@@ -831,21 +831,21 @@ working with the <code>Result</code> type, make good use of them!</p>
 <p>In Gleam if a function can either succeed or fail then it normally will
 return the <code>Result</code> type. With <code>Result</code>, a successful return value is wrapped
 in an <code>Ok</code> record, and an error value is wrapped in an <code>Error</code> record.</p>
-<pre><code class="language-rust noplaypen">// parse_int(String) -&gt; Result(Int, String)
+<pre><code class="language-gleam">// parse_int(String) -&gt; Result(Int, String)
 
 parse_int(&quot;123&quot;) // -&gt; Ok(123)
 parse_int(&quot;erl&quot;) // -&gt; Error(&quot;expected a number, got `erl`&quot;)
 </code></pre>
 <p>When a function returns a <code>Result</code> we can pattern match on it to handle success
 and failure:</p>
-<pre><code class="language-rust noplaypen">case parse_int(&quot;123&quot;) {
+<pre><code class="language-gleam">case parse_int(&quot;123&quot;) {
   Error(e) -&gt; io.println(&quot;That wasn't an Int&quot;)
   Ok(i) -&gt; io.println(&quot;We parsed the Int&quot;)
 }
 </code></pre>
 <p>This is such a common pattern in Gleam that the <code>try</code> syntax exists to make it
 more consise.</p>
-<pre><code class="language-rust noplaypen">try int_a = parse_int(a)
+<pre><code class="language-gleam">try int_a = parse_int(a)
 try int_b = parse_int(b)
 try int_c = parse_int(c)
 Ok(int_a + int_b + int_c)
@@ -853,12 +853,12 @@ Ok(int_a + int_b + int_c)
 <p>When a variable is declared using <code>try</code> Gleam checks to see whether the value
 is an Error or an Ok record. If it's an Ok then the inner value is assigned to
 the variable:</p>
-<pre><code class="language-rust noplaypen">try x = Ok(1)
+<pre><code class="language-gleam">try x = Ok(1)
 Ok(x + 1)
 // -&gt; Ok(2)
 </code></pre>
 <p>If it's an Error then the Error is returned immediately:</p>
-<pre><code class="language-rust noplaypen">try x = Error(&quot;failure&quot;)
+<pre><code class="language-gleam">try x = Error(&quot;failure&quot;)
 Ok(x + 1)
 // -&gt; Error(&quot;failure&quot;)
 </code></pre>
@@ -878,13 +878,13 @@ the database to handle the request.</p>
 prototype application, so we want to only spend time on the success path for now.</p>
 <p>For these situations Gleam provides <code>assert</code>, a keyword that causes the
 program to crash if a pattern does not match.</p>
-<pre><code class="language-rust noplaypen">assert Ok(i) = parse_int(&quot;123&quot;)
+<pre><code class="language-gleam">assert Ok(i) = parse_int(&quot;123&quot;)
 i // =&gt; 123
 </code></pre>
 <p>Here the <code>assert</code> keyword has been used to say &quot;this function must return an
 <code>Ok</code> value&quot; and we haven't had to write any error handling. The inner value
 is assigned the variable <code>i</code> and the program continues.</p>
-<pre><code class="language-rust noplaypen">assert Ok(i) = parse_int(&quot;not an int&quot;)
+<pre><code class="language-gleam">assert Ok(i) = parse_int(&quot;not an int&quot;)
 </code></pre>
 <p>In this case the <code>parse_int</code> function returns and error, so the <code>Ok(i)</code>
 pattern doesn't match and so the program crashes.</p>
@@ -898,7 +898,7 @@ supervisors</a>.</p>
 <p>Gleam's <code>todo</code> keyword is used to indicate that some code is not yet finished.</p>
 <p>It can be useful when designing a module, type checking functions and types
 but leaving the implementation of the functions until later.</p>
-<pre><code class="language-rust noplaypen">fn favourite_number() -&gt; Int {
+<pre><code class="language-gleam">fn favourite_number() -&gt; Int {
   // The type annotations says this returns an Int, but we don't need
   // to implement it yet.
   todo
@@ -913,7 +913,7 @@ it is valid, and the <code>todo</code> will be replaced with code that crashes t
 program if that function is run.</p>
 <p>A message can be given as a form of documentation. The message will be printed
 in the error message when the <code>todo</code> code is run.</p>
-<pre><code class="language-rust noplaypen">fn favourite_number() -&gt; Int {
+<pre><code class="language-gleam">fn favourite_number() -&gt; Int {
   todo(&quot;We're going to decide which number is best tomorrow&quot;)
 }
 </code></pre>
@@ -922,7 +922,7 @@ to avoid accidentally forgetting to remove a <code>todo</code>.</p>
 <p>The warning also includes the expected type of the expression that needs to
 replace the <code>todo</code>. This can be a useful way of asking the compiler what type
 is needed if you are ever unsure.</p>
-<pre><code class="language-rust noplaypen">fn main() {
+<pre><code class="language-gleam">fn main() {
   my_complicated_function(
     // What type does this function take again...?
     todo
@@ -932,7 +932,7 @@ is needed if you are ever unsure.</p>
 <h1><a class="header" href="#constants" id="constants">Constants</a></h1>
 <p>Gleam's module constants provide a way to use a certain fixed value in
 multiple places in a Gleam project.</p>
-<pre><code class="language-rust noplaypen">pub const start_year = 2101
+<pre><code class="language-gleam">pub const start_year = 2101
 pub const end_year = 2111
 
 pub fn is_before(year: Int) -&gt; Bool {
@@ -947,7 +947,7 @@ pub fn is_during(year: Int) -&gt; Bool {
 changed, so they cannot be used as global mutable state.</p>
 <p>When a constant is referenced the value is inlined by the compiler, so they
 can be used in case expression guards.</p>
-<pre><code class="language-rust noplaypen">pub const start_year = 2101
+<pre><code class="language-gleam">pub const start_year = 2101
 pub const end_year = 2111
 
 pub describe(year: Int) -&gt; String {
@@ -960,7 +960,7 @@ pub describe(year: Int) -&gt; String {
 </code></pre>
 <h2><a class="header" href="#type-annotations-1" id="type-annotations-1">Type annotations</a></h2>
 <p>Constants can also be given type annotations. </p>
-<pre><code class="language-rust noplaypen">pub const name: String = &quot;Gleam&quot;
+<pre><code class="language-gleam">pub const name: String = &quot;Gleam&quot;
 pub const size: Int = 100
 </code></pre>
 <p>These annotations serve as documentation or can be used to provide a more 
@@ -971,13 +971,13 @@ useful when the name of the type may be long and awkward to type repeatedly.</p>
 <p>Here we are giving the type <code>List(tuple(String, String))</code> the new name
 <code>Headers</code>. This may be useful in a web application where we want to write
 multiple functions that return headers.</p>
-<pre><code class="language-rust noplaypen">pub type Headers =
+<pre><code class="language-gleam">pub type Headers =
   List(tuple(String, String))
 </code></pre>
 <h1><a class="header" href="#bit-strings" id="bit-strings">Bit strings</a></h1>
 <p>Gleam offers a syntax for working directly with raw data in the form of bit
 strings.</p>
-<pre><code class="language-rust noplaypen">// A bit string of the 8 bit int value 3
+<pre><code class="language-gleam">// A bit string of the 8 bit int value 3
 &lt;&lt;3&gt;&gt;
 
 // A bit string of the utf8 encoded string &quot;Gleam&quot;
@@ -1005,19 +1005,19 @@ arguments and returns a <code>Float</code>.</p>
 prints it, and returns the same value.</p>
 <p>If we want to import these functions and use them in our program we would do
 so like this:</p>
-<pre><code class="language-rust noplaypen">pub external fn random_float() -&gt; Float = &quot;rand&quot; &quot;uniform&quot;
+<pre><code class="language-gleam">pub external fn random_float() -&gt; Float = &quot;rand&quot; &quot;uniform&quot;
 
 // Elixir modules start with `Elixir.`
 pub external fn inspect(a) -&gt; a = &quot;Elixir.IO&quot; &quot;inspect&quot;
 </code></pre>
 <h2><a class="header" href="#labelled-arguments-1" id="labelled-arguments-1">Labelled arguments</a></h2>
 <p>Like regular functions, external functions can have labelled arguments.</p>
-<pre><code class="language-rust noplaypen">pub external fn any(in: List(a), satisfying: fn(a) -&gt; Bool) =
+<pre><code class="language-gleam">pub external fn any(in: List(a), satisfying: fn(a) -&gt; Bool) =
   &quot;my_external_module&quot; &quot;any&quot;
 </code></pre>
 <p>This function has the labelled arguments <code>in</code> and <code>satisfying</code>, and can be
 called like so:</p>
-<pre><code class="language-rust noplaypen">any(in: my_list, satisfying: is_even)
+<pre><code class="language-gleam">any(in: my_list, satisfying: is_even)
 any(satisfying: is_even, in: my_list)
 </code></pre>
 <h1><a class="header" href="#external-type" id="external-type">External type</a></h1>
@@ -1027,7 +1027,7 @@ they cannot be pattern matched on, but they can be used with external
 functions that know how to work with them.</p>
 <p>Here is an example of importing a <code>Queue</code> data type and some functions from
 Erlang's <code>queue</code> module to work with the new <code>Queue</code> type.</p>
-<pre><code class="language-rust noplaypen">pub external type Queue(a)
+<pre><code class="language-gleam">pub external type Queue(a)
 
 pub external fn new() -&gt; Queue(a) = &quot;queue&quot; &quot;new&quot;
 
@@ -1082,6 +1082,8 @@ pub external fn push(Queue(a), a) -&gt; Queue(a) = &quot;queue&quot; &quot;in&qu
         <script src="book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/searcher.js
+++ b/book/searcher.js
@@ -145,6 +145,11 @@ window.search = window.search || {};
             url.push("");
         }
 
+        // encodeURIComponent escapes all chars that could allow an XSS except
+        // for '. Due to that we also manually replace ' with its url-encoded
+        // representation (%27).
+        var searchterms = encodeURIComponent(searchterms.join(" ")).replace(/\'/g, "%27");
+
         return '<a href="' + path_to_root + url[0] + '?' + URL_MARK_PARAM + '=' + searchterms + '#' + url[1]
             + '" aria-details="teaser_' + teaser_count + '">' + result.doc.breadcrumbs + '</a>'
             + '<span class="teaser" id="teaser_' + teaser_count + '" aria-label="Search Result Teaser">' 

--- a/book/tour/assert.html
+++ b/book/tour/assert.html
@@ -179,13 +179,13 @@ the database to handle the request.</p>
 prototype application, so we want to only spend time on the success path for now.</p>
 <p>For these situations Gleam provides <code>assert</code>, a keyword that causes the
 program to crash if a pattern does not match.</p>
-<pre><code class="language-rust noplaypen">assert Ok(i) = parse_int(&quot;123&quot;)
+<pre><code class="language-gleam">assert Ok(i) = parse_int(&quot;123&quot;)
 i // =&gt; 123
 </code></pre>
 <p>Here the <code>assert</code> keyword has been used to say &quot;this function must return an
 <code>Ok</code> value&quot; and we haven't had to write any error handling. The inner value
 is assigned the variable <code>i</code> and the program continues.</p>
-<pre><code class="language-rust noplaypen">assert Ok(i) = parse_int(&quot;not an int&quot;)
+<pre><code class="language-gleam">assert Ok(i) = parse_int(&quot;not an int&quot;)
 </code></pre>
 <p>In this case the <code>parse_int</code> function returns and error, so the <code>Ok(i)</code>
 pattern doesn't match and so the program crashes.</p>
@@ -258,6 +258,8 @@ supervisors</a>.</p>
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/bit-strings.html
+++ b/book/tour/bit-strings.html
@@ -166,7 +166,7 @@
                         <h1><a class="header" href="#bit-strings" id="bit-strings">Bit strings</a></h1>
 <p>Gleam offers a syntax for working directly with raw data in the form of bit
 strings.</p>
-<pre><code class="language-rust noplaypen">// A bit string of the 8 bit int value 3
+<pre><code class="language-gleam">// A bit string of the 8 bit int value 3
 &lt;&lt;3&gt;&gt;
 
 // A bit string of the utf8 encoded string &quot;Gleam&quot;
@@ -240,6 +240,8 @@ documentation</a></p>
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/bools.html
+++ b/book/tour/bools.html
@@ -166,7 +166,7 @@
                         <h1><a class="header" href="#bool" id="bool">Bool</a></h1>
 <p>A Bool can be either <code>True</code> or <code>False</code>.</p>
 <p>Gleam defines a handful of operators that work with Bools.</p>
-<pre><code class="language-rust noplaypen">False &amp;&amp; False // =&gt; False
+<pre><code class="language-gleam">False &amp;&amp; False // =&gt; False
 False &amp;&amp; True  // =&gt; False
 True &amp;&amp; False  // =&gt; False
 True &amp;&amp; True   // =&gt; True
@@ -186,7 +186,7 @@ runtime with the atoms <code>true</code> and <code>false</code>, making them com
 and Erlang's booleans.</p>
 <p>This is important if you want to use Gleam and Elixir or Erlang together in
 one project.</p>
-<pre><code class="language-rust noplaypen">// Gleam
+<pre><code class="language-gleam">// Gleam
 True
 False
 </code></pre>
@@ -257,6 +257,8 @@ false.
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/case-expressions.html
+++ b/book/tour/case-expressions.html
@@ -170,7 +170,7 @@ allows us to say &quot;if the data has this shape then do that&quot;, which we c
 <p>Here we match on an <code>Int</code> and return a specific string for the values 0, 1,
 and 2. The final pattern <code>n</code> matches any other value that did not match any of
 the previous patterns.</p>
-<pre><code class="language-rust noplaypen">case some_number {
+<pre><code class="language-gleam">case some_number {
   0 -&gt; &quot;Zero&quot;
   1 -&gt; &quot;One&quot;
   2 -&gt; &quot;Two&quot;
@@ -179,7 +179,7 @@ the previous patterns.</p>
 </code></pre>
 <p>Pattern matching on a <code>Bool</code> value is the Gleam alternative to the <code>if else</code>
 statement found in other languages.</p>
-<pre><code class="language-rust noplaypen">case some_bool {
+<pre><code class="language-gleam">case some_bool {
   True -&gt; &quot;It's true!&quot;
   False -&gt; &quot;It's not true.&quot;
 }
@@ -187,7 +187,7 @@ statement found in other languages.</p>
 <p>Gleam's <code>case</code> is an expression, meaning it returns a value and can be used
 anywhere we would use a value. For example, we can name the value of a case
 expression with a <code>let</code> binding.</p>
-<pre><code class="language-rust noplaypen">let description =
+<pre><code class="language-gleam">let description =
   case True {
     True -&gt; &quot;It's true!&quot;
     False -&gt; &quot;It's not true.&quot;
@@ -198,7 +198,7 @@ description  // =&gt; &quot;It's true!&quot;
 <h2><a class="header" href="#destructuring" id="destructuring">Destructuring</a></h2>
 <p>A <code>case</code> expression can be used to destructure values that
 contain other values, such as tuples and lists.</p>
-<pre><code class="language-rust noplaypen">case xs {
+<pre><code class="language-gleam">case xs {
   [] -&gt; &quot;This list is empty&quot;
   [a] -&gt; &quot;This list has 1 element&quot;
   [a, b] -&gt; &quot;This list has 2 elements&quot;
@@ -208,7 +208,7 @@ contain other values, such as tuples and lists.</p>
 <p>It's not just the top level data structure that can be pattern matches,
 contained values can also be matched. This gives <code>case</code> the ability to
 concisely express flow control that might be verbose without pattern matching.</p>
-<pre><code class="language-rust noplaypen">case xs {
+<pre><code class="language-gleam">case xs {
   [[]] -&gt; &quot;The only element is an empty list&quot;
   [[], ..] -&gt; &quot;The 1st element is an empty list&quot;
   [[4], ..] -&gt; &quot;The 1st element is a list of the number 4&quot;
@@ -217,13 +217,13 @@ concisely express flow control that might be verbose without pattern matching.</
 </code></pre>
 <p>Pattern matching also works in <code>let</code> bindings, though patterns that do not
 match all instances of that type may result in a runtime error.</p>
-<pre><code class="language-rust noplaypen">let [a] = [1]    // a is 1
+<pre><code class="language-gleam">let [a] = [1]    // a is 1
 let [b] = [1, 2] // Runtime error! The pattern has 1 element but the value has 2
 </code></pre>
 <h2><a class="header" href="#matching-on-multiple-values" id="matching-on-multiple-values">Matching on multiple values</a></h2>
 <p>Sometimes it is useful to pattern match on multiple values at the same time,
 so <code>case</code> supports having multiple subjects.</p>
-<pre><code class="language-rust noplaypen">case x, y {
+<pre><code class="language-gleam">case x, y {
   1, 1 -&gt; &quot;both are 1&quot;
   1, _ -&gt; &quot;x is 1&quot;
   _, 1 -&gt; &quot;y is 1&quot;
@@ -233,7 +233,7 @@ so <code>case</code> supports having multiple subjects.</p>
 <h2><a class="header" href="#assigning-names-to-sub-patterns" id="assigning-names-to-sub-patterns">Assigning names to sub-patterns</a></h2>
 <p>Sometimes when pattern matching we want to assign a name to a value while
 specifying its shape at the same time. We can do this using the <code>as</code> keyword.</p>
-<pre><code class="language-rust noplaypen">case xs {
+<pre><code class="language-gleam">case xs {
   [[_, ..] as inner_list] -&gt; inner_list
   other -&gt; []
 }
@@ -243,12 +243,12 @@ specifying its shape at the same time. We can do this using the <code>as</code> 
 the patterns have to match and the guard has to evaluate to <code>True</code> for the
 clause to match. The guard expression can check for equality or ordering for
 <code>Int</code> and <code>Float</code>.</p>
-<pre><code class="language-rust noplaypen">case xs {
+<pre><code class="language-gleam">case xs {
   [a, b, c] if a == b &amp;&amp; b != c -&gt; &quot;ok&quot;
   _other -&gt; &quot;ko&quot;
 }
 </code></pre>
-<pre><code class="language-rust noplaypen">case xs {
+<pre><code class="language-gleam">case xs {
   [a, b, c] if a &gt;. b &amp;&amp; a &lt;=. c -&gt; &quot;ok&quot;
   _other -&gt; &quot;ko&quot;
 }
@@ -257,7 +257,7 @@ clause to match. The guard expression can check for equality or ordering for
 <p>Alternative patterns can be given for a case clause using the <code>|</code> operator. If
 any of the patterns match then the clause matches.</p>
 <p>Here the first clause will match if the variable <code>number</code> holds 2, 4, 6 or 8.</p>
-<pre><code class="language-rust noplaypen">case number {
+<pre><code class="language-gleam">case number {
   2 | 4 | 6 | 8 -&gt; &quot;This is an even number&quot;
   1 | 3 | 5 | 7 -&gt; &quot;This is an odd number&quot;
   _ -&gt; &quot;I'm not sure&quot;
@@ -265,7 +265,7 @@ any of the patterns match then the clause matches.</p>
 </code></pre>
 <p>If the patterns declare variables then the same variables must be declared in
 all patterns, and the variables must have the same type in all the patterns.</p>
-<pre><code class="language-rust noplaypen">case list {
+<pre><code class="language-gleam">case list {
   [1, x] | x -&gt; x // Error! Int != List(Int)
   _ -&gt; 0
 }
@@ -333,6 +333,8 @@ all patterns, and the variables must have the same type in all the patterns.</p>
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/comments.html
+++ b/book/tour/comments.html
@@ -166,22 +166,22 @@
                         <h1><a class="header" href="#comments" id="comments">Comments</a></h1>
 <p>Gleam allows you to write comments in your code.</p>
 <p>Here’s a simple comment:</p>
-<pre><code class="language-rust noplaypen">// Hello, world!
+<pre><code class="language-gleam">// Hello, world!
 </code></pre>
 <p>In Gleam, comments must start with two slashes and continue until the end of the
 line. For comments that extend beyond a single line, you’ll need to include
 <code>//</code> on each line, like this:</p>
-<pre><code class="language-rust noplaypen">// Hello, world! I have a lot to say, so much that it will take multiple
+<pre><code class="language-gleam">// Hello, world! I have a lot to say, so much that it will take multiple
 // lines of text. Therefore, I will start each line with // to denote it
 // as part of a multi-line comment.
 </code></pre>
 <p>Comments can also be placed at the end of lines containing code:</p>
-<pre><code class="language-rust noplaypen">pub fn add(x, y) {
+<pre><code class="language-gleam">pub fn add(x, y) {
   x + y // here we are adding two values together
 }
 </code></pre>
 <p>Comments may also be indented:</p>
-<pre><code class="language-rust noplaypen">pub fn multiply(x, y) {
+<pre><code class="language-gleam">pub fn multiply(x, y) {
   // here we are multiplying x by y
   x * y 
 }
@@ -249,6 +249,8 @@ line. For comments that extend beyond a single line, you’ll need to include
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/constants.html
+++ b/book/tour/constants.html
@@ -166,7 +166,7 @@
                         <h1><a class="header" href="#constants" id="constants">Constants</a></h1>
 <p>Gleam's module constants provide a way to use a certain fixed value in
 multiple places in a Gleam project.</p>
-<pre><code class="language-rust noplaypen">pub const start_year = 2101
+<pre><code class="language-gleam">pub const start_year = 2101
 pub const end_year = 2111
 
 pub fn is_before(year: Int) -&gt; Bool {
@@ -181,7 +181,7 @@ pub fn is_during(year: Int) -&gt; Bool {
 changed, so they cannot be used as global mutable state.</p>
 <p>When a constant is referenced the value is inlined by the compiler, so they
 can be used in case expression guards.</p>
-<pre><code class="language-rust noplaypen">pub const start_year = 2101
+<pre><code class="language-gleam">pub const start_year = 2101
 pub const end_year = 2111
 
 pub describe(year: Int) -&gt; String {
@@ -194,7 +194,7 @@ pub describe(year: Int) -&gt; String {
 </code></pre>
 <h2><a class="header" href="#type-annotations" id="type-annotations">Type annotations</a></h2>
 <p>Constants can also be given type annotations. </p>
-<pre><code class="language-rust noplaypen">pub const name: String = &quot;Gleam&quot;
+<pre><code class="language-gleam">pub const name: String = &quot;Gleam&quot;
 pub const size: Int = 100
 </code></pre>
 <p>These annotations serve as documentation or can be used to provide a more 
@@ -262,6 +262,8 @@ specific type than the compiler would otherwise infer.</p>
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/custom-types.html
+++ b/book/tour/custom-types.html
@@ -168,7 +168,7 @@
 similar to objects in object oriented languages, though they don't have
 methods.</p>
 <p>Custom types are defined with the <code>type</code> keyword.</p>
-<pre><code class="language-rust noplaypen">pub type Cat {
+<pre><code class="language-gleam">pub type Cat {
   Cat(name: String, cuteness: Int)
 }
 </code></pre>
@@ -177,7 +177,7 @@ methods.</p>
 <code>cuteness</code> field which is an <code>Int</code>.</p>
 <p>The <code>pub</code> keyword makes this type usable from other modules.</p>
 <p>Once defined the custom type can be used in functions:</p>
-<pre><code class="language-rust noplaypen">fn cats() {
+<pre><code class="language-gleam">fn cats() {
   // Labelled fields can be given in any order
   let cat1 = Cat(name: &quot;Nubi&quot;, cuteness: 2001)
   let cat2 = Cat(cuteness: 1805, name: &quot;Biffy&quot;)
@@ -196,7 +196,7 @@ way of modeling data that can be one of a few different variants.</p>
 <li><a href="./bools.html"><code>Bool</code></a>.</li>
 </ul>
 <p>The built-in Gleam's <code>Bool</code> type is defined like this:</p>
-<pre><code class="language-rust noplaypen">// A Bool is a value that is either `True` or `False`
+<pre><code class="language-gleam">// A Bool is a value that is either `True` or `False`
 pub type Bool {
   True
   False
@@ -209,19 +209,19 @@ or <code>False</code>.</p>
 different values. For example a <code>User</code> custom type could have a <code>LoggedIn</code>
 constructors that creates records with a name, and a <code>Guest</code> constructor which
 creates records without any contained values.</p>
-<pre><code class="language-rust noplaypen">type User {
+<pre><code class="language-gleam">type User {
   LoggedIn(name: String)  // A logged in user with a name
   Guest                   // A guest user with no details
 }
 </code></pre>
-<pre><code class="language-rust noplaypen">let sara = LoggedIn(name: &quot;Sara&quot;)
+<pre><code class="language-gleam">let sara = LoggedIn(name: &quot;Sara&quot;)
 let rick = LoggedIn(name: &quot;Rick&quot;)
 let visitor = Guest
 </code></pre>
 <h2><a class="header" href="#destructuring" id="destructuring">Destructuring</a></h2>
 <p>When given a custom type record we can pattern match on it to determine which
 record constructor matches, and to assign names to any contained values.</p>
-<pre><code class="language-rust noplaypen">fn get_name(user) {
+<pre><code class="language-gleam">fn get_name(user) {
   case user {
     LoggedIn(name) -&gt; name
     Guest -&gt; &quot;Guest user&quot;
@@ -229,11 +229,11 @@ record constructor matches, and to assign names to any contained values.</p>
 }
 </code></pre>
 <p>Custom types can also be destructured with a <code>let</code> binding.</p>
-<pre><code class="language-rust noplaypen">type Score {
+<pre><code class="language-gleam">type Score {
   Points(Int)
 }
 </code></pre>
-<pre><code class="language-rust noplaypen">let score = Points(50)
+<pre><code class="language-gleam">let score = Points(50)
 let Points(p) = score
 
 p // =&gt; 50
@@ -246,7 +246,7 @@ publically exported functions.</p>
 incremented. We don't want the user to alter the int value other than by
 incrementing it, so we can make the type opaque to prevent them from being
 able to do this.</p>
-<pre><code class="language-rust noplaypen">// The type is defined with the opaque keyword
+<pre><code class="language-gleam">// The type is defined with the opaque keyword
 pub opaque type Counter {
   Counter(value: Int)
 }
@@ -267,7 +267,7 @@ type using the exported functions from the module, in this case <code>new</code>
 <h2><a class="header" href="#record-updates" id="record-updates">Record updates</a></h2>
 <p>Gleam provides a dedicated syntax for updating some of the fields of a custom
 type record.</p>
-<pre><code class="language-rust noplaypen">pub type Person {
+<pre><code class="language-gleam">pub type Person {
   Person(
     name: String,
     gender: Option(String),
@@ -293,7 +293,7 @@ becomes <code>logged_in</code>.</p>
 <p>Custom type records with contained values are Erlang records. The Gleam
 compiler generates an Erlang header file with a record definition for each
 constructor, for use from Erlang.</p>
-<pre><code class="language-rust noplaypen">// Gleam
+<pre><code class="language-gleam">// Gleam
 Guest
 LoggedIn(&quot;Kim&quot;)
 </code></pre>
@@ -368,6 +368,8 @@ guest,
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/expression-blocks.html
+++ b/book/tour/expression-blocks.html
@@ -166,7 +166,7 @@
                         <h1><a class="header" href="#expression-blocks" id="expression-blocks">Expression blocks</a></h1>
 <p>Every block in gleam is an expression. All expressions in the block are
 executed, and the result of the last expression is returned.</p>
-<pre><code class="language-rust noplaypen">let value: Bool = {
+<pre><code class="language-gleam">let value: Bool = {
     &quot;Hello&quot;
     42 + 12
     False
@@ -174,7 +174,7 @@ executed, and the result of the last expression is returned.</p>
 </code></pre>
 <p>Expression blocks can be used instead of parenthesis to change the precedence
 of operations.</p>
-<pre><code class="language-rust noplaypen">let celsius = { fahrenheit - 32 } * 5 / 9
+<pre><code class="language-gleam">let celsius = { fahrenheit - 32 } * 5 / 9
 </code></pre>
 
                     </main>
@@ -239,6 +239,8 @@ of operations.</p>
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/external-functions.html
+++ b/book/tour/external-functions.html
@@ -180,19 +180,19 @@ arguments and returns a <code>Float</code>.</p>
 prints it, and returns the same value.</p>
 <p>If we want to import these functions and use them in our program we would do
 so like this:</p>
-<pre><code class="language-rust noplaypen">pub external fn random_float() -&gt; Float = &quot;rand&quot; &quot;uniform&quot;
+<pre><code class="language-gleam">pub external fn random_float() -&gt; Float = &quot;rand&quot; &quot;uniform&quot;
 
 // Elixir modules start with `Elixir.`
 pub external fn inspect(a) -&gt; a = &quot;Elixir.IO&quot; &quot;inspect&quot;
 </code></pre>
 <h2><a class="header" href="#labelled-arguments" id="labelled-arguments">Labelled arguments</a></h2>
 <p>Like regular functions, external functions can have labelled arguments.</p>
-<pre><code class="language-rust noplaypen">pub external fn any(in: List(a), satisfying: fn(a) -&gt; Bool) =
+<pre><code class="language-gleam">pub external fn any(in: List(a), satisfying: fn(a) -&gt; Bool) =
   &quot;my_external_module&quot; &quot;any&quot;
 </code></pre>
 <p>This function has the labelled arguments <code>in</code> and <code>satisfying</code>, and can be
 called like so:</p>
-<pre><code class="language-rust noplaypen">any(in: my_list, satisfying: is_even)
+<pre><code class="language-gleam">any(in: my_list, satisfying: is_even)
 any(satisfying: is_even, in: my_list)
 </code></pre>
 
@@ -258,6 +258,8 @@ any(satisfying: is_even, in: my_list)
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/external-types.html
+++ b/book/tour/external-types.html
@@ -170,7 +170,7 @@ they cannot be pattern matched on, but they can be used with external
 functions that know how to work with them.</p>
 <p>Here is an example of importing a <code>Queue</code> data type and some functions from
 Erlang's <code>queue</code> module to work with the new <code>Queue</code> type.</p>
-<pre><code class="language-rust noplaypen">pub external type Queue(a)
+<pre><code class="language-gleam">pub external type Queue(a)
 
 pub external fn new() -&gt; Queue(a) = &quot;queue&quot; &quot;new&quot;
 
@@ -233,6 +233,8 @@ pub external fn push(Queue(a), a) -&gt; Queue(a) = &quot;queue&quot; &quot;in&qu
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/functions.html
+++ b/book/tour/functions.html
@@ -166,7 +166,7 @@
                         <h1><a class="header" href="#function" id="function">Function</a></h1>
 <h2><a class="header" href="#named-functions" id="named-functions">Named functions</a></h2>
 <p>Named functions in Gleam are defined using the <code>pub fn</code> keywords.</p>
-<pre><code class="language-rust noplaypen">pub fn add(x: Int, y: Int) -&gt; Int {
+<pre><code class="language-gleam">pub fn add(x: Int, y: Int) -&gt; Int {
   x + y
 }
 
@@ -176,7 +176,7 @@ pub fn multiply(x: Int, y: Int) -&gt; Int {
 </code></pre>
 <p>Functions in Gleam are first class values and so can be assigned to variables,
 passed to functions, or anything else you might do with any other data type.</p>
-<pre><code class="language-rust noplaypen">// This function takes a function as an argument
+<pre><code class="language-gleam">// This function takes a function as an argument
 pub fn twice(f: fn(t) -&gt; t, x: t) -&gt; t {
   f(f(x))
 }
@@ -192,10 +192,10 @@ pub fn add_two(x: Int) -&gt; Int {
 <h2><a class="header" href="#pipe-operator" id="pipe-operator">Pipe Operator</a></h2>
 <p>Gleam provides syntax for passing the result of one function to the arguments of another function, the pipe operator (<code>|&gt;</code>). This is similar in functionality to the same operator in Elixir or F#.</p>
 <p>The pipe operator allows you to chain function calls without using a plethora of parenthesis. For a simple example, consider the following implementation of <code>string.reverse</code> in Gleam:</p>
-<pre><code class="language-rust noplaypen">iodata.to_string(iodata.reverse(iodata.new(string)))
+<pre><code class="language-gleam">iodata.to_string(iodata.reverse(iodata.new(string)))
 </code></pre>
 <p>This can be expressed more naturally using the pipe operator, eliminating the need to track parenthesis closure.</p>
-<pre><code class="language-rust noplaypen">string
+<pre><code class="language-gleam">string
 |&gt; iodata.new
 |&gt; iodata.reverse
 |&gt; iodata.to_string
@@ -204,7 +204,7 @@ pub fn add_two(x: Int) -&gt; Int {
 <h2><a class="header" href="#type-annotations" id="type-annotations">Type annotations</a></h2>
 <p>Function arguments are normally annotated with their type, and the
 compiler will check these annotations and ensure they are correct.</p>
-<pre><code class="language-rust noplaypen">fn identity(x: some_type) -&gt; some_type {
+<pre><code class="language-gleam">fn identity(x: some_type) -&gt; some_type {
   x
 }
 
@@ -223,12 +223,12 @@ remember what the arguments are, and what order they are expected in.</p>
 <p>To help with this Gleam supports <em>labelled arguments</em>, where function
 arguments are given an external label in addition to their internal name.</p>
 <p>Take this function that replaces sections of a string:</p>
-<pre><code class="language-rust noplaypen">pub fn replace(string: String, pattern: String, replacement: String) {
+<pre><code class="language-gleam">pub fn replace(string: String, pattern: String, replacement: String) {
   // ...
 }
 </code></pre>
 <p>It can be given labels like so.</p>
-<pre><code class="language-rust noplaypen">pub fn replace(
+<pre><code class="language-gleam">pub fn replace(
   in string: String,
   each pattern: String,
   with replacement: String,
@@ -237,7 +237,7 @@ arguments are given an external label in addition to their internal name.</p>
 }
 </code></pre>
 <p>These labels can then be used when calling the function.</p>
-<pre><code class="language-rust noplaypen">replace(in: &quot;A,B,C&quot;, each: &quot;,&quot;, with: &quot; &quot;)
+<pre><code class="language-gleam">replace(in: &quot;A,B,C&quot;, each: &quot;,&quot;, with: &quot; &quot;)
 
 // Labelled arguments can be given in any order
 replace(each: &quot;,&quot;, with: &quot; &quot;, in: &quot;A,B,C&quot;)
@@ -250,7 +250,7 @@ sentence-like manner, while still providing a function body that is readable
 and clear in intent.</p>
 <h2><a class="header" href="#anonymous-functions" id="anonymous-functions">Anonymous functions</a></h2>
 <p>Anonymous functions can be defined with a similar syntax.</p>
-<pre><code class="language-rust noplaypen">pub fn run() {
+<pre><code class="language-gleam">pub fn run() {
   let add = fn(x, y) { x + y }
 
   add(1, 2)
@@ -260,7 +260,7 @@ and clear in intent.</p>
 <p>There is a shorthand syntax for creating anonymous functions that take one
 argument and call another function. The <code>_</code> is used to indicate where the
 argument should be passed.</p>
-<pre><code class="language-rust noplaypen">pub fn add(x, y) {
+<pre><code class="language-gleam">pub fn add(x, y) {
   x + y
 }
 
@@ -272,7 +272,7 @@ pub fn run() {
 </code></pre>
 <p>The function capture syntax is often used with the pipe operator to create
 a series of transformations on some data.</p>
-<pre><code class="language-rust noplaypen">pub fn add(x: Int , y: Int ) -&gt; Int {
+<pre><code class="language-gleam">pub fn add(x: Int , y: Int ) -&gt; Int {
   x + y
 }
 
@@ -285,7 +285,7 @@ pub fn run() {
 }
 </code></pre>
 <p>In fact, this usage is so common that there is a special shorthand for it.</p>
-<pre><code class="language-rust noplaypen">pub fn run() {
+<pre><code class="language-gleam">pub fn run() {
   // This is the same as the example above
   1
   |&gt; add(3)
@@ -360,6 +360,8 @@ as the first argument to the call, e.g. <code>a |&gt; b(1, 2)</code> would becom
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/index.html
+++ b/book/tour/index.html
@@ -228,6 +228,8 @@ information can be safely ignored.</p>
 
         <!-- Custom JS scripts -->
         
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
+        
 
         
 

--- a/book/tour/ints-and-floats.html
+++ b/book/tour/ints-and-floats.html
@@ -167,13 +167,13 @@
 <p>Gleam's main number types are Int and Float.</p>
 <h2><a class="header" href="#ints" id="ints">Ints</a></h2>
 <p>Ints are &quot;whole&quot; numbers.</p>
-<pre><code class="language-rust noplaypen">1
+<pre><code class="language-gleam">1
 2
 -3
 4001
 </code></pre>
 <p>Gleam has several operators that work with Ints.</p>
-<pre><code class="language-rust noplaypen">1 + 1 // =&gt; 2
+<pre><code class="language-gleam">1 + 1 // =&gt; 2
 5 - 1 // =&gt; 4
 5 / 2 // =&gt; 2
 3 * 3 // =&gt; 9
@@ -185,16 +185,16 @@
 2 &lt;= 1 // =&gt; False
 </code></pre>
 <p>Underscores can be added to Ints for clarity.</p>
-<pre><code class="language-rust noplaypen">1_000_000 // One million
+<pre><code class="language-gleam">1_000_000 // One million
 </code></pre>
 <h2><a class="header" href="#floats" id="floats">Floats</a></h2>
 <p>Floats are numbers that have a decimal point.</p>
-<pre><code class="language-rust noplaypen">1.5
+<pre><code class="language-gleam">1.5
 2.0
 -0.1
 </code></pre>
 <p>Floats also have their own set of operators.</p>
-<pre><code class="language-rust noplaypen">1.0 +. 1.4 // =&gt; 2.4
+<pre><code class="language-gleam">1.0 +. 1.4 // =&gt; 2.4
 5.0 -. 1.5 // =&gt; 3.5
 5.0 /. 2.0 // =&gt; 2.5
 3.0 *. 3.1 // =&gt; 9.3
@@ -205,7 +205,7 @@
 2.0 &lt;=. 1.0 // =&gt; False
 </code></pre>
 <p>Underscores can also be added to Floats for clarity.</p>
-<pre><code class="language-rust noplaypen">1_000_000.0 // One million
+<pre><code class="language-gleam">1_000_000.0 // One million
 </code></pre>
 
                     </main>
@@ -270,6 +270,8 @@
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/let-bindings.html
+++ b/book/tour/let-bindings.html
@@ -167,7 +167,7 @@
 <p>A value can be given a name using <code>let</code>. Names can be reused by later let
 bindings, but the values contained are <em>immutable</em>, meaning the values
 themselves cannot be changed.</p>
-<pre><code class="language-rust noplaypen">let x = 1
+<pre><code class="language-gleam">let x = 1
 let y = x
 let x = 2
 
@@ -237,6 +237,8 @@ y  // =&gt; 1
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/lists.html
+++ b/book/tour/lists.html
@@ -169,17 +169,17 @@ structures in Gleam.</p>
 <p>Lists are <em>homogeneous</em>, meaning all the elements of a List must be of the
 same type. Attempting to construct a list of multiple types of element will
 result in the compiler presenting a type error.</p>
-<pre><code class="language-rust noplaypen">[1, 2, 3, 4]  // List(Int)
+<pre><code class="language-gleam">[1, 2, 3, 4]  // List(Int)
 [1.22, 2.30]  // List(Float)
 [1.22, 3, 4]  // Type error!
 </code></pre>
 <p>Prepending to a list is very fast, and is the preferred way to add new values.</p>
-<pre><code class="language-rust noplaypen">[1, ..[2, 3]]  // =&gt; [1, 2, 3]
+<pre><code class="language-gleam">[1, ..[2, 3]]  // =&gt; [1, 2, 3]
 </code></pre>
 <p>Note that as all data structures in Gleam are immutable so prepending to a
 list does not change the original list, instead it efficiently creates a new
 list with the new additional element.</p>
-<pre><code class="language-rust noplaypen">let x = [2, 3]
+<pre><code class="language-gleam">let x = [2, 3]
 let y = [1, ..x]
 
 
@@ -249,6 +249,8 @@ y  // =&gt; [1, 2, 3]
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/modules.html
+++ b/book/tour/modules.html
@@ -167,7 +167,7 @@
 <p>Gleam programs are made up of bundles of functions and types called modules.
 Each module has its own namespace and can export types and values to be used
 by other modules in the program.</p>
-<pre><code class="language-rust noplaypen">// inside src/nasa/rocket_ship.gleam
+<pre><code class="language-gleam">// inside src/nasa/rocket_ship.gleam
 
 fn count_down() {
   &quot;3... 2... 1...&quot;
@@ -194,7 +194,7 @@ called by other functions within the same module.</p>
 <h2><a class="header" href="#import" id="import">Import</a></h2>
 <p>To use functions or types from another module we need to import them using the
 <code>import</code> keyword.</p>
-<pre><code class="language-rust noplaypen">// inside src/nasa/moon_base.gleam
+<pre><code class="language-gleam">// inside src/nasa/moon_base.gleam
 
 import nasa/rocket_ship
 
@@ -211,14 +211,14 @@ error as this function is private in the <code>rocket_ship</code> module.</p>
 <h2><a class="header" href="#named-import" id="named-import">Named import</a></h2>
 <p>It is also possible to give a module a custom name when importing it using the
 <code>as</code> keyword.</p>
-<pre><code class="language-rust noplaypen">import unix/cat
+<pre><code class="language-gleam">import unix/cat
 import animal/cat as kitty
 </code></pre>
 <p>This may be useful to differentiate between multiple modules that would have
 the same default name when imported.</p>
 <h2><a class="header" href="#unqualified-import" id="unqualified-import">Unqualified import</a></h2>
 <p>Values and types can also be imported in an unqualified fashion.</p>
-<pre><code class="language-rust noplaypen">import animal/cat.{Cat, stroke}
+<pre><code class="language-gleam">import animal/cat.{Cat, stroke}
 
 pub fn main() {
   let kitty = Cat(name: &quot;Nubi&quot;)
@@ -291,6 +291,8 @@ value is defined.</p>
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/result.html
+++ b/book/tour/result.html
@@ -164,7 +164,7 @@
                 <div id="content" class="content">
                     <main>
                         <h1><a class="header" href="#resultvalue-error" id="resultvalue-error"><code>Result(value, error)</code></a></h1>
-<pre><code class="language-rust noplaypen">pub type Result(value, reason) {
+<pre><code class="language-gleam">pub type Result(value, reason) {
   Ok(value)
   Error(reason)
 }
@@ -173,14 +173,14 @@
 instead we have the <code>Result</code> type. If a function call fails, wrap the returned
 value in a <code>Result</code>, either <code>Ok</code> if the function was successful, or <code>Error</code>
 if it failed.</p>
-<pre><code class="language-rust noplaypen">pub fn lookup(name, phone_book) {
+<pre><code class="language-gleam">pub fn lookup(name, phone_book) {
   // ... we found a phone number in the phone book for the given name here
   Ok(phone_number)
 }
 </code></pre>
 <p>The <code>Error</code> type needs to be given a reason for the failure in order to
 return, like so:</p>
-<pre><code class="language-rust noplaypen">pub type MyDatabaseError {
+<pre><code class="language-gleam">pub type MyDatabaseError {
   InvalidQuery
   NetworkTimeout
 }
@@ -193,7 +193,7 @@ pub fn insert(db_row) {
 <p>In cases where we don't care about the specific error enough to want to create
 a custom error type, or when the cause of the error is obvious without further
 detail, the <code>Nil</code> type can be used as the <code>Error</code> reason.</p>
-<pre><code class="language-rust noplaypen">pub fn lookup(name, phone_book) {
+<pre><code class="language-gleam">pub fn lookup(name, phone_book) {
   // ... That name wasn't found in the phone book
   Error(Nil)
 }
@@ -266,6 +266,8 @@ working with the <code>Result</code> type, make good use of them!</p>
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/strings.html
+++ b/book/tour/strings.html
@@ -165,14 +165,14 @@
                     <main>
                         <h1><a class="header" href="#string" id="string">String</a></h1>
 <p>Gleam's has UTF-8 binary strings, written as text surrounded by double quotes.</p>
-<pre><code class="language-rust noplaypen">&quot;Hello, Gleam!&quot;
+<pre><code class="language-gleam">&quot;Hello, Gleam!&quot;
 </code></pre>
 <p>Strings can span multiple lines.</p>
-<pre><code class="language-rust noplaypen">&quot;Hello
+<pre><code class="language-gleam">&quot;Hello
 Gleam!&quot;
 </code></pre>
 <p>Special characters such as <code>&quot;</code> need to be escaped with a <code>\</code> character.</p>
-<pre><code class="language-rust noplaypen">&quot;Here is a double quote -&gt; \&quot; &lt;-&quot;
+<pre><code class="language-gleam">&quot;Here is a double quote -&gt; \&quot; &lt;-&quot;
 </code></pre>
 
                     </main>
@@ -237,6 +237,8 @@ Gleam!&quot;
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/todo.html
+++ b/book/tour/todo.html
@@ -167,7 +167,7 @@
 <p>Gleam's <code>todo</code> keyword is used to indicate that some code is not yet finished.</p>
 <p>It can be useful when designing a module, type checking functions and types
 but leaving the implementation of the functions until later.</p>
-<pre><code class="language-rust noplaypen">fn favourite_number() -&gt; Int {
+<pre><code class="language-gleam">fn favourite_number() -&gt; Int {
   // The type annotations says this returns an Int, but we don't need
   // to implement it yet.
   todo
@@ -182,7 +182,7 @@ it is valid, and the <code>todo</code> will be replaced with code that crashes t
 program if that function is run.</p>
 <p>A message can be given as a form of documentation. The message will be printed
 in the error message when the <code>todo</code> code is run.</p>
-<pre><code class="language-rust noplaypen">fn favourite_number() -&gt; Int {
+<pre><code class="language-gleam">fn favourite_number() -&gt; Int {
   todo(&quot;We're going to decide which number is best tomorrow&quot;)
 }
 </code></pre>
@@ -191,7 +191,7 @@ to avoid accidentally forgetting to remove a <code>todo</code>.</p>
 <p>The warning also includes the expected type of the expression that needs to
 replace the <code>todo</code>. This can be a useful way of asking the compiler what type
 is needed if you are ever unsure.</p>
-<pre><code class="language-rust noplaypen">fn main() {
+<pre><code class="language-gleam">fn main() {
   my_complicated_function(
     // What type does this function take again...?
     todo
@@ -261,6 +261,8 @@ is needed if you are ever unsure.</p>
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/try.html
+++ b/book/tour/try.html
@@ -167,21 +167,21 @@
 <p>In Gleam if a function can either succeed or fail then it normally will
 return the <code>Result</code> type. With <code>Result</code>, a successful return value is wrapped
 in an <code>Ok</code> record, and an error value is wrapped in an <code>Error</code> record.</p>
-<pre><code class="language-rust noplaypen">// parse_int(String) -&gt; Result(Int, String)
+<pre><code class="language-gleam">// parse_int(String) -&gt; Result(Int, String)
 
 parse_int(&quot;123&quot;) // -&gt; Ok(123)
 parse_int(&quot;erl&quot;) // -&gt; Error(&quot;expected a number, got `erl`&quot;)
 </code></pre>
 <p>When a function returns a <code>Result</code> we can pattern match on it to handle success
 and failure:</p>
-<pre><code class="language-rust noplaypen">case parse_int(&quot;123&quot;) {
+<pre><code class="language-gleam">case parse_int(&quot;123&quot;) {
   Error(e) -&gt; io.println(&quot;That wasn't an Int&quot;)
   Ok(i) -&gt; io.println(&quot;We parsed the Int&quot;)
 }
 </code></pre>
 <p>This is such a common pattern in Gleam that the <code>try</code> syntax exists to make it
 more consise.</p>
-<pre><code class="language-rust noplaypen">try int_a = parse_int(a)
+<pre><code class="language-gleam">try int_a = parse_int(a)
 try int_b = parse_int(b)
 try int_c = parse_int(c)
 Ok(int_a + int_b + int_c)
@@ -189,12 +189,12 @@ Ok(int_a + int_b + int_c)
 <p>When a variable is declared using <code>try</code> Gleam checks to see whether the value
 is an Error or an Ok record. If it's an Ok then the inner value is assigned to
 the variable:</p>
-<pre><code class="language-rust noplaypen">try x = Ok(1)
+<pre><code class="language-gleam">try x = Ok(1)
 Ok(x + 1)
 // -&gt; Ok(2)
 </code></pre>
 <p>If it's an Error then the Error is returned immediately:</p>
-<pre><code class="language-rust noplaypen">try x = Error(&quot;failure&quot;)
+<pre><code class="language-gleam">try x = Error(&quot;failure&quot;)
 Ok(x + 1)
 // -&gt; Error(&quot;failure&quot;)
 </code></pre>
@@ -261,6 +261,8 @@ Ok(x + 1)
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/tuples.html
+++ b/book/tour/tuples.html
@@ -167,7 +167,7 @@
 <p>Lists are good for when we want a collection of one type, but sometime we want
 to combine multiple values of different types. In this case tuples are a quick
 and convenient option.</p>
-<pre><code class="language-rust noplaypen">fn run() {
+<pre><code class="language-gleam">fn run() {
   tuple(10, &quot;hello&quot;) // Type is tuple(Int, String)
   tuple(1, 4.2, [0]) // Type is tuple(Int, Float, List(Int))
 }
@@ -235,6 +235,8 @@ and convenient option.</p>
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/book/tour/type-aliases.html
+++ b/book/tour/type-aliases.html
@@ -169,7 +169,7 @@ useful when the name of the type may be long and awkward to type repeatedly.</p>
 <p>Here we are giving the type <code>List(tuple(String, String))</code> the new name
 <code>Headers</code>. This may be useful in a web application where we want to write
 multiple functions that return headers.</p>
-<pre><code class="language-rust noplaypen">pub type Headers =
+<pre><code class="language-gleam">pub type Headers =
   List(tuple(String, String))
 </code></pre>
 
@@ -235,6 +235,8 @@ multiple functions that return headers.</p>
         <script src="../book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
+        
+        <script type="text/javascript" src="../javascript/highlightjs-gleam.js"></script>
         
 
         

--- a/javascript/highlightjs-gleam.js
+++ b/javascript/highlightjs-gleam.js
@@ -1,0 +1,105 @@
+hljs.registerLanguage("gleam", function (hljs) {
+  const KEYWORDS =
+    "as assert case const external fn if import let " +
+    "opaque pub todo try tuple type";
+  const STRING = {
+    className: "string",
+    variants: [{ begin: /"/, end: /"/ }],
+    contains: [hljs.BACKSLASH_ESCAPE],
+    relevance: 0,
+  };
+  const NAME = {
+    className: "variable",
+    begin: "\\b[a-z][a-z0-9_]*\\b",
+    relevance: 0,
+  };
+  const DISCARD_NAME = {
+    className: "comment",
+    begin: "\\b_[a-z][a-z0-9_]*\\b",
+    relevance: 0,
+  };
+  const NUMBER = {
+    className: "number",
+    variants: [
+      {
+        begin: "\\b0b([01_]+)",
+      },
+      {
+        begin: "\\b0o([0-7_]+)",
+      },
+      {
+        begin: "\\b0x([A-Fa-f0-9_]+)",
+      },
+      {
+        begin: "\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)",
+      },
+    ],
+    relevance: 0,
+  };
+
+  return {
+    name: "Gleam",
+    aliases: ["gleam"],
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      STRING,
+      {
+        // bitstrings
+        begin: "<<",
+        end: ">>",
+        contains: [
+          {
+            className: "keyword",
+            beginKeywords:
+              "binary bytes int float bit_string bits utf8 utf16 utf32 " +
+              "utf8_codepoint utf16_codepoint utf32_codepoint signed unsigned " +
+              "big little native unit size",
+          },
+          STRING,
+          NUMBER,
+          NAME,
+          DISCARD_NAME,
+        ],
+        relevance: 10,
+      },
+      {
+        className: "function",
+        beginKeywords: "fn",
+        end: "\\(",
+        excludeEnd: true,
+        contains: [
+          {
+            className: "title",
+            begin: "[a-zA-Z0-9_]\\w*",
+            relevance: 0,
+          },
+        ],
+      },
+      {
+        className: "keyword",
+        beginKeywords: KEYWORDS,
+      },
+      {
+        // Type names and constructors
+        className: "title",
+        begin: "\\b[A-Z][A-Za-z0-9_]*\\b",
+        relevance: 0,
+      },
+      {
+        // float operators
+        className: "operator",
+        begin: "(\\+\\.|-\\.|\\*\\.|/\\.|<\\.|>\\.)",
+        relevance: 10,
+      },
+      {
+        className: "operator",
+        begin: "(->|\\|>|<<|>>|\\+|-|\\*|/|>=|<=|<|<|%|\\.\\.|\\|=|==|!=)",
+        relevance: 0,
+      },
+      NUMBER,
+      NAME,
+      DISCARD_NAME,
+    ],
+  };
+});
+hljs.initHighlightingOnLoad();


### PR DESCRIPTION
Not sure you're interested in this but I added proper syntax highlighting to the gleam snippets in the book.

I'm sure there's a better way to load this module but I'm not super familiar with including JS in mdbook. So `highlight.js` has been overridden directly to include the gleam highlighter.

A proper module for highlightjs is available in npm https://www.npmjs.com/package/highlightjs-gleam in case anyone knows how to properly load it in mdbook.

Here's some examples:

![Screen Shot 2021-01-07 at 7 55 04 PM](https://user-images.githubusercontent.com/6858318/103965591-acd0c380-5123-11eb-9921-d5120fa0164a.jpg)
![Screen Shot 2021-01-07 at 7 51 23 PM](https://user-images.githubusercontent.com/6858318/103965596-ae01f080-5123-11eb-9315-c5f2cbd74603.jpg)
![Screen Shot 2021-01-07 at 7 52 42 PM](https://user-images.githubusercontent.com/6858318/103965598-ae9a8700-5123-11eb-9911-a90fcba5c6cc.jpg)
