### PR TITLE
Fix typo in Elixir operators

### DIFF
--- a/cheatsheets/gleam-for-elixir-users.md
+++ b/cheatsheets/gleam-for-elixir-users.md
@@ -289,8 +289,8 @@ const answer: Int = 42
 | Greater or equal  | `>=`   | `>=.` | In Gleam both values must be **floats**        |
 | Less than         | `<`    | `<`   | In Gleam both values must be **ints**          |
 | Less than         | `<`    | `<.`  | In Gleam both values must be **floats**        |
-| Less or equal     | `=<`   | `>=`  | In Gleam both values must be **ints**          |
-| Less or equal     | `=<`   | `>=.` | In Gleam both values must be **floats**        |
+| Less or equal     | `<=`   | `>=`  | In Gleam both values must be **ints**          |
+| Less or equal     | `<=`   | `>=.` | In Gleam both values must be **floats**        |
 | Boolean and       | `and`  | `&&`  | Both values must be **bools**                  |
 | Logical and       | `&&`   |       | Not available in Gleam                         |
 | Boolean or        | `or`   | `|| ` | Both values must be **bools**                  |


### PR DESCRIPTION
`<=` was written as `=<` in the table comparing Elixir and Gleam operators.

In Elixir `=<` gives us SyntaxError, while `<=` is the "Less or equal" operator.