### PR TITLE
Fix repository.type examples in gleam.toml

### DIFF
--- a/writing-gleam/gleam-toml.md
+++ b/writing-gleam/gleam-toml.md
@@ -43,10 +43,10 @@ This enables source links, in the generated documentation, from types, constants
 their defining lines of code in the repository.
 
 ```toml
-repository = { type = "GitHub", user = "example", repo = "project" }
-repository = { type = "GitLab", user = "example", repo = "project" }
-repository = { type = "BitBucket", user = "example", repo = "project" }
-repository = { type = "Custom", url = "https://repo.example.com" }
+repository = { type = "github", user = "example", repo = "project" }
+repository = { type = "gitlab", user = "example", repo = "project" }
+repository = { type = "bitbucket", user = "example", repo = "project" }
+repository = { type = "custom", url = "https://repo.example.com" }
 ```
 
 ## `docs`


### PR DESCRIPTION
See https://github.com/gleam-lang/gleam/blob/a474ef64f67b16cf98e8e7b1e2d71819152a7a3a/src/config.rs#L42-L50.