### PR TITLE
Correct docs commands examples

### DIFF
--- a/writing-gleam/documenting-the-project.md
+++ b/writing-gleam/documenting-the-project.md
@@ -93,7 +93,7 @@ documentation to `gen/docs`.
 
 ```sh
 cd path/to/project
-gleam docs build
+gleam docs build --version 1.0.0
 ```
 
 Once you are happy with the documentation it can be pushed to HexDocs, the
@@ -104,7 +104,7 @@ manager before attempting to publish the documentation for that version.
 
 ```sh
 cd path/to/project
-gleam docs publish --version v1.0.0
+gleam docs publish --version 1.0.0
 ```
 
 Lastly, if you wish to remove documentation from HexDoc (possibly to correct
@@ -112,5 +112,5 @@ an error) then this command can be used:
 
 ```sh
 cd path/to/project
-gleam docs remove --package my_project_name --version v1.0.0
+gleam docs remove --package my_project_name --version 1.0.0
 ```


### PR DESCRIPTION
- `--version` is a required arg for the `gleam docs build` command
- The value for `--version` must match the value in `.app.src`, which means that it must be valid semver, which means (I think) that it must not have a `v` preceding it... or at least I can't find any examples of that version format in the [`rebar3 docs`](https://rebar3.org/docs/package_management/publishing-packages/) or the [`hex.pm docs`](https://hex.pm/docs/rebar3_publish), and so it would be atypical.