### PR TITLE
Rust Cheatsheet: Use the assigned value

### DIFF
--- a/cheatsheets/gleam-for-rust-users.md
+++ b/cheatsheets/gleam-for-rust-users.md
@@ -242,7 +242,7 @@ fn identity(x: u64) -> u64 {
 
 fn main() {
   let func = identity;
-  identity(100);
+  func(100);
 }
 ```
 


### PR DESCRIPTION
I'm not sure if this is valid rust but the way the doc reads, it feels like this is the intent.