### PR TITLE
Fix anonymous function call in Elixir guide

### DIFF
--- a/cheatsheets/gleam-for-elixir-users.md
+++ b/cheatsheets/gleam-for-elixir-users.md
@@ -263,7 +263,7 @@ end
 
 def main() do
   func = &identity/1
-  func(100)
+  func.(100)
 end
 ```
 


### PR DESCRIPTION
These gleam-for-x guides are really a great thing to have!

I noticed this small issue with one of the Elixir examples