### PR TITLE
Add link to Elm cheatsheet & sort list

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -23,6 +23,7 @@ layout: page
 - [Gleam for Elixir users](/cheatsheets/gleam-for-elixir-users)
 - [Gleam for Rust users](/cheatsheets/gleam-for-rust-users)
 - [Gleam for Python users](/cheatsheets/gleam-for-python-users)
+- [Gleam for Elm users](/cheatsheets/gleam-for-elm-users)
 
 ## Gleam references
 

--- a/documentation.md
+++ b/documentation.md
@@ -19,11 +19,11 @@ layout: page
 
 ## Cheatsheets
 
-- [Gleam for Erlang users](/cheatsheets/gleam-for-erlang-users)
 - [Gleam for Elixir users](/cheatsheets/gleam-for-elixir-users)
-- [Gleam for Rust users](/cheatsheets/gleam-for-rust-users)
-- [Gleam for Python users](/cheatsheets/gleam-for-python-users)
 - [Gleam for Elm users](/cheatsheets/gleam-for-elm-users)
+- [Gleam for Erlang users](/cheatsheets/gleam-for-erlang-users)
+- [Gleam for Python users](/cheatsheets/gleam-for-python-users)
+- [Gleam for Rust users](/cheatsheets/gleam-for-rust-users)
 
 ## Gleam references
 


### PR DESCRIPTION
Not sure if you want the list sorted. I can remove that commit if preferable. Just seems like it is getting to a length where an order is sensible.