### PR TITLE
Fix errors/typos in gleam-for-elm

### DIFF
--- a/cheatsheets/gleam-for-elm-users.md
+++ b/cheatsheets/gleam-for-elm-users.md
@@ -242,9 +242,9 @@ Elm has no built in way to label arguments. Instead it would standard for a func
 
 ```elm
 defaultOptions =
-  { inside : defaultString
-  , each : defaultPattern,
-  , with : defaultReplacement
+  { inside = defaultString
+  , each = defaultPattern,
+  , with = defaultReplacement
   }
 
 replace opts =
@@ -252,9 +252,9 @@ replace opts =
 ```
 
 ```elm
-replace { each: ",", with: " ", inside: "A,B,C" }
+replace { each = ",", with = " ", inside = "A,B,C" }
 
-replace { defaultOptions | inside: "A,B,C,D" }
+replace { defaultOptions | inside = "A,B,C,D" }
 ```
 
 #### Gleam
@@ -356,7 +356,7 @@ view =
          z = 4
          t = 3
       in
-      z + (t * 5) -- Parenthesis are used to gropu arithmetic expressions
+      z + (t * 5) -- Parenthesis are used to group arithmetic expressions
   in
   y + x
 end
@@ -440,7 +440,7 @@ Tuples are very useful in both Elm and Gleam as they're the only collection data
 
 #### Elm
 
-In Elm, tuplies are limited to only 2 or 3 entries. It is recommended to use records for more larger numbers of entries.
+In Elm, tuples are limited to only 2 or 3 entries. It is recommended to use records for more larger numbers of entries.
 
 ```elm
 myTuple = ("username", "password", 10)
@@ -471,14 +471,14 @@ person =
   }
 ```
 
-The type of the record is derived by the compiler. In this case it would be `{ name : String, age : Int }`.
+The type of the record is derived by the compiler. In this case it would be `{ name : String, age : number }`.
 
 Records can also be created using a [type alias](#type-aliases) name as a constructor.
 
 Record fields can be accessed with a dot syntax:
 
 ```elm
-greeting = 
+greeting person = 
    "Hello, " ++ person.name ++ "!"
 ```
 
@@ -810,7 +810,6 @@ type Alignment
   = Left
   | Centre
   | Right
-
 ```
 
 #### Gleam


### PR DESCRIPTION
Hi there :wave: 
Thanks a lot for this great guide @michaeljones. I noticed a few errors/typos so I thought I'd make a PR.

Additionally, I noticed a few problems that I didn't fix, which I've described below:

> It is recommended to use records for more larger numbers of entries.

This sentence reads weird, but I didn't suggest an alternative because I figured that could be rejected and could delay merging this PR.

> You can pattern match on lists in Elm, but only in case-statements.

While I think this is useful to know, the example afterwards demonstrates list construction, not pattern matching, which is confusing. Maybe talk about the `::` operator right before the example?


> Elm uses type aliases to define the layout of records. Gleam uses Custom Types to achieve a similar result.

Elm uses type aliases for other things than records. I understand from this that Gleam type aliases can only be for records? Is that right, or could this be phrased differently?


> Javascript

It's JavaScript with a capital S. I didn't want to change this everywhere for this PR.

> It is not possible to publish an Elm package that includes Javascript script

script -> code?