### PR TITLE
Add Highlight JS based syntax highlighting of Gleam code

### DIFF
--- a/_layouts/top.html
+++ b/_layouts/top.html
@@ -11,6 +11,9 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Karla&display=swap">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap"> 
     <link rel="stylesheet" href="/styles/index.css?v=2">
+    <link id="syntax-theme" rel="stylesheet" href="https://unpkg.com/@highlightjs/cdn-assets@10.5.0/styles/atom-one-light.min.css">
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.0.1/highlight.min.js"></script>
+    <script src="/javascript/highlightjs-gleam.js"></script>
     <link rel="shortcut icon" href="/images/lucy-charcoal-2.svg">
     {% feed_meta %}
     <meta name="description" content="{{ description }}">

--- a/_posts/2019-04-15-hello-gleam.md
+++ b/_posts/2019-04-15-hello-gleam.md
@@ -16,7 +16,7 @@ OCaml, ReasonML, or Elm then I hope you will enjoy Gleam.
 
 It looks something like this:
 
-```rust
+```gleam
 pub enum User =
   | LoggedIn(String)
   | Guest

--- a/_posts/2019-08-07-gleam-v0.3-released.md
+++ b/_posts/2019-08-07-gleam-v0.3-released.md
@@ -32,7 +32,7 @@ src/
 Once created these modules can be brought into scope using the `import`
 statement.
 
-```rust
+```gleam
 import snackr/customer
 import snackr/food/falafel
 
@@ -44,7 +44,7 @@ fn eat_lunch(louis) {
 It's now possible to use multiple modules with the same name, so for
 convenience modules can be given a name when imported.
 
-```rust
+```gleam
 import space/rocket as spaceship
 import salad/rocket as leafy_green
 ```
@@ -59,7 +59,7 @@ otherwise infer.
 
 It looks a little something like this:
 
-```rust
+```gleam
 fn is_empty(list: List(a)) -> Bool {
   list == []
 }

--- a/_posts/2019-09-19-gleam-v0.4-released.md
+++ b/_posts/2019-09-19-gleam-v0.4-released.md
@@ -24,7 +24,7 @@ scanned in order to find a field to access it.
 
 Unlike either struct types are declared up-front by the `struct` keyword.
 
-```rust
+```gleam
 pub struct Cat {
   name: String
   cuteness: Int
@@ -34,7 +34,7 @@ pub struct Cat {
 Once declared the newly defined constructor can be used to create instances of
 the struct.
 
-```rust
+```gleam
 pub fn cats() {
   let cat1 = Cat(name: "Nubi", cuteness: 2001)
   let cat2 = Cat(cuteness: 1805, name: "Biffy")
@@ -66,13 +66,13 @@ For example, with the `Order` enum we would expect `Gt` (greater than) to be
 larger than `Lt` (less than), but according to Erlang's value ordering this is
 not the case.
 
-```rust
+```gleam
 enum Order =
   | Gt
   | Eq
   | Lt
 ```
-```rust
+```gleam
 Gt > Lt  // => False
 ```
 
@@ -105,7 +105,7 @@ accessing a field on a module, so the `:` operator has been removed and
 replaced with the `.` operator, making it the universal operator for accessing
 a named field on a module or container data type in Gleam.
 
-```rust
+```gleam
 import gleam/list
 
 pub fn main() {

--- a/_posts/2019-12-16-gleam-v0.5-released.md
+++ b/_posts/2019-12-16-gleam-v0.5-released.md
@@ -19,7 +19,7 @@ arguments are given an external label in addition to their internal name.
 
 Take this function that replaces sections of a string:
 
-```rust
+```gleam
 pub fn replace(string, pattern, replacement) {
   // ...
 }
@@ -27,7 +27,7 @@ pub fn replace(string, pattern, replacement) {
 
 It can be given labels like so.
 
-```rust
+```gleam
 pub fn replace(in string, each pattern, with replacement) {
   // The variables `string`, `pattern`, and `replacement` are in scope here
 }
@@ -35,7 +35,7 @@ pub fn replace(in string, each pattern, with replacement) {
 
 These labels can then be used when calling the function.
 
-```rust
+```gleam
 replace(in: "A,B,C", each: ",", with: " ")
 
 // Labelled arguments can be given in any order
@@ -62,7 +62,7 @@ and blocks felt a little strange or not in keeping with the wider language.
 In response to this we have adopted a syntax closer to that found in
 C-influenced languages such as ECMAScript.
 
-```rust
+```gleam
 case x {
   1 -> "It's one"
   2 -> "It's two"
@@ -74,7 +74,7 @@ case x {
   }
 }
 ```
-```rust
+```gleam
 pub enum Cardinal {
   North
   East
@@ -90,7 +90,7 @@ Often it is useful to pattern match on multiple values at the same time.
 Previously in Gleam the solution was to wrap the values in a struct and
 pattern match on all values at once.
 
-```rust
+```gleam
 case Pair(x, y) {
   Pair(1, 1) -> "both are 1"
   Pair(1, _) -> "x is 1"
@@ -102,7 +102,7 @@ case Pair(x, y) {
 To remove some boilerplate here Gleam's case expression now supports pattern
 matching on multiple values.
 
-```rust
+```gleam
 case x, y {
   1, 1 -> "both are 1"
   1, _ -> "x is 1"
@@ -128,7 +128,7 @@ definition header file is generated for each struct which can be imported into
 an Erlang project or used from Elixir using the [Record](https://hexdocs.pm/elixir/Record.html)
 module.
 
-```rust
+```gleam
 // src/cat.gleam
 
 pub struct Cat {
@@ -180,7 +180,7 @@ the first position.
 Anonymous structs map 1 to 1 onto Erlang tuples can are useful for any
 situation where interop with Erlang tuples is required.
 
-```rust
+```gleam
 fn main() {
   struct(10, "hello") // Type is struct(Int, String)
   struct(1, 4.2, [0]) // Type is struct(Int, Float, List(Int))
@@ -197,7 +197,7 @@ than 2 or 3 fields.
 Tired of typing module names repeatedly for imported types and values? Well
 now you don't have to.
 
-```rust
+```gleam
 import animal/cat.{Cat, stroke}
 
 pub fn main() {

--- a/_posts/2019-12-25-gleam-v0.6-released.md
+++ b/_posts/2019-12-25-gleam-v0.6-released.md
@@ -12,7 +12,7 @@ This release has one big change to how we define data structures in Gleam. To
 understand it lets take a look at how structs and enums have worked up until
 this point.
 
-```rust
+```gleam
 struct Cat {
   name: String
   age: Int
@@ -22,7 +22,7 @@ struct Cat {
 Structs are collections of named values. Under the hood they are represented
 as Erlang tuples, so `Cat("Nubi", 2)` would be `{<<"Nubi">>, 2}` in Erlang.
 
-```rust
+```gleam
 enum SchoolPerson {
   Teacher(String, Subject)
   Student(String)
@@ -66,14 +66,14 @@ Structs became a subset of enums, so why have both?
 With v0.6 rather than structs and enums we have _custom types_. Here's how the
 two examples above would be written using the new syntax:
 
-```rust
+```gleam
 type Cat {
   Cat(name: String, age: Int)
 }
 ```
 Cat is a custom type has a single constructor called Cat.
 
-```rust
+```gleam
 type SchoolPerson {
   Teacher(name: String, class: Subject)
   Student(name: String)
@@ -82,7 +82,7 @@ type SchoolPerson {
 
 SchoolPerson is a custom type has a Teacher constructor and a Student constructor.
 
-```rust
+```gleam
 let louis = Student(name: "Louis")
 ```
 
@@ -100,7 +100,7 @@ After this change `struct` is no longer a keyword, and it doesn't make much
 sense to have a concept of anonymous structs without named structs, so
 anonymous structs have been renamed _tuples_.
 
-```rust
+```gleam
 let pair = tuple(1, "two")
 ```
 

--- a/_posts/2020-03-01-gleam-v0.7-released.md
+++ b/_posts/2020-03-01-gleam-v0.7-released.md
@@ -52,7 +52,7 @@ need we're introducing alternative patterns, separated by the `|` operator.
 In this case expression the first clause will match if the variable `number`
 holds 2, 4, 6 or 8.
 
-```rust
+```gleam
 case number {
   2 | 4 | 6 | 8 -> "This is an even number"
   1 | 3 | 5 | 7 -> "This is an odd number"
@@ -67,7 +67,7 @@ Sometimes when pattern matching we want to assert that two variables have the
 same value. Before this release we'd need to nested case expressions, now we
 have clause guards.
 
-```rust
+```gleam
 case xs {
   [a, b] if a == b -> "Two equal elements"
   [a, b] if a != b -> "Two unequal elements"
@@ -82,7 +82,7 @@ Sometimes when pattern matching we want to assign a name to a value while
 specifying it's shape at the same time. With this release we can now do this
 using the `as` keyword.
 
-```rust
+```gleam
 case xs {
   [[_, _] as inner_list] -> inner_list
   other -> []
@@ -98,7 +98,7 @@ short alias instead such as `Option(Headers)`. With type aliases this is now
 possible.
 
 
-```rust
+```gleam
 pub type Option(value) =
   Result(value, Nil)
 

--- a/_posts/2020-05-07-gleam-v0.8-released.md
+++ b/_posts/2020-05-07-gleam-v0.8-released.md
@@ -64,7 +64,7 @@ chains of functions that read top-to-bottom and left-to-right.
 It works by taking the value on the left hand side and using it as the
 argument to the function on the right hand side.
 
-```rust
+```gleam
 // Without pipe
 print(eval(read(stdin)), stdout)
 
@@ -77,7 +77,7 @@ In the example above the function "print" takes two arguments, so the function
 side value. In practice most Gleam functions take multiple arguments, so the
 capture syntax is needed more often than not.
 
-```rust
+```gleam
 scores
 |> list.map(_, double)
 |> list.fold(_, 0, add)
@@ -91,7 +91,7 @@ pipe will first check to see if the left hand value could be used as the first
 argument to the call (`b(a, 1, 2)`), and if not it falls back to calling the
 result of the right hand side as a function (`b(1, 2)(a)`).
 
-```rust
+```gleam
 scores
 |> list.map(double)
 |> list.fold(0, add)
@@ -111,7 +111,7 @@ that's common in other languages.
 
 It works with records:
 
-```rust
+```gleam
 let student = Student(subject: "Theatre")
 let mary = Person(name: "Mary", role: student)
 
@@ -121,7 +121,7 @@ mary.role.subject // => "Theatre"
 
 And it works with tuples:
 
-```rust
+```gleam
 let pair = tuple("Apples", "Oranges")
 
 pair.0 // => "Apples"
@@ -134,7 +134,7 @@ pair.1 // => "Oranges"
 Gleam's pattern matching has been expanded with a new operator called the
 spread operator, which allows you to write a partial pattern for a record.
 
-```rust
+```gleam
 // Without spread
 let Uri(
   scheme: scheme,
@@ -155,7 +155,7 @@ To be consistent with records the syntax for prepending to a list and for
 matching on the head of a list have been updated to also use the spread
 operator.
 
-```rust
+```gleam
 let new_list = [1, 2, 3, ..existing_list]
 
 case list {

--- a/_posts/2020-06-01-gleam-v0.9-released.md
+++ b/_posts/2020-06-01-gleam-v0.9-released.md
@@ -18,7 +18,7 @@ The main way that errors are represented and handled in Gleam is through the
 Result type. It's baked into the language itself, but if you were to implement
 it in a library it would be implemented like so:
 
-```rust
+```gleam
 pub type Result(success_value, failure_detail) {
   Ok(success_value)
   Error(failure_detail)
@@ -29,7 +29,7 @@ If a function can fail then it returns a Result, wrapping a successful return
 value in an Ok record, or returning detail on the failure in an Error record
 if it's not successful.
 
-```rust
+```gleam
 // parse_int(String) -> Result(Int, String)
 
 parse_int("123") // -> Ok(123)
@@ -39,7 +39,7 @@ parse_int("erl") // -> Error("expected a number, got `erl`")
 When a function returns a Result we can pattern match on it to handle success
 and failure:
 
-```rust
+```gleam
 case parse_int("123") {
   Error(e) -> io.println("That wasn't an Int")
   Ok(i) -> io.println("We parsed the Int")
@@ -50,7 +50,7 @@ This works but if you need to handle multiple Result values in the same
 function then it becomes verbose, and the error handling obscures the business
 logic.
 
-```rust
+```gleam
 case parse_int(a) {
   Error(e) -> Error(e)
   Ok(int_a) -> case parse_int(b) {
@@ -67,7 +67,7 @@ With this release Gleam now has the `try` keyword which makes error handling
 easier and more concise. Rewritten using `try` the previous example looks like
 this:
 
-```rust
+```gleam
 try int_a = parse_int(a)
 try int_b = parse_int(b)
 try int_c = parse_int(c)
@@ -78,14 +78,14 @@ When a variable is declared using `try` Gleam checks to see whether the value
 is an Error or an Ok record. If it's an Ok then the inner value is assigned to
 the variable:
 
-```rust
+```gleam
 try x = Ok(1)
 Ok(x + 1)
 // -> Ok(2)
 ```
 If it's an Error then the Error is returned immediately:
 
-```rust
+```gleam
 try x = Error("failure")
 Ok(x + 1)
 // -> Error("failure")
@@ -100,7 +100,7 @@ with how it cleans up error handling. Why not give it a try? 😜
 Gleam's new opaque type feature allows a library writer to export a custom
 type without exporting the internal details of the type.
 
-```rust
+```gleam
 // in src/box.gleam
 pub opaque type Box {
   Box(inner_value: Int)
@@ -115,7 +115,7 @@ If another module imports this custom type they will be able to create a `Box`
 using the `new` function, but they cannot call the `Box` constructor, use the
 `.inner_value` accessor, or pattern match on a Box to get the inner value.
 
-```rust
+```gleam
 import box
 
 let one = box.new(1) // This is permitted
@@ -147,7 +147,7 @@ elements currently being processed to be in memory.
 Here we can see the Iterator type used to create an infinitely long sequence
 of Ints, which is then mapped over, and the first 5 elements are evaluated.
 
-```rust
+```gleam
 import gleam/iterator
 
 let double = fn(x) { x * 2 }
@@ -172,7 +172,7 @@ documentation](https://hexdocs.pm/gleam_stdlib/gleam/iterator/).
 A Set is a collection value. Unlike a List, it is unordered, cannot contain
 duplicate values, and finding a value in a Set is very fast.
 
-```rust
+```gleam
 import gleam/set
 
 let pop_band = set.new(["Iris", "Karl", "Priya"])
@@ -194,7 +194,7 @@ A Queue is an ordered collection of elements. It's similar to a List, however
 it's fast to add and remove from both ends of a queue, while a list can only
 be quickly accessed from the front.
 
-```rust
+```gleam
 import gleam/queue
 
 queue.new()
@@ -215,7 +215,7 @@ documentation](https://hexdocs.pm/gleam_stdlib/gleam/queue/).
 Option is a type used to represent values which may be present or absent,
 making it similar to nullable values in other languages. It's defined like so:
 
-```rust
+```gleam
 pub type Option(a) {
   Some(a)
   None

--- a/_posts/2020-07-01-gleam-v0.10-released.md
+++ b/_posts/2020-07-01-gleam-v0.10-released.md
@@ -18,7 +18,7 @@ Sometimes we want to use a certain fixed value in multiple places in our
 project. Until now we've had two options. The first option was to copy and
 paste the value into multiple places in our code.
 
-```rust
+```gleam
 pub fn is_before(year: Int) -> Bool {
   year < 2101
 }
@@ -35,7 +35,7 @@ to change it.
 Another option is to wrap the value in a function.
 
 
-```rust
+```gleam
 pub fn start_year() -> Int {
   2101
 }
@@ -61,7 +61,7 @@ does.
 To make matters worse Gleam's case clause guards don't support calling of
 functions within them, so this code will be rejected by the compiler:
 
-```rust
+```gleam
 pub describe(year: Int) -> String {
   case year {
     year if year < start_year() -> "Before"
@@ -77,7 +77,7 @@ inlined by the compiler, and can be used in case clause guards.
 Using them the above code can be rewritten like so:
 
 
-```rust
+```gleam
 pub const start_year: Int = 2101
 pub const end_year: Int = 2111
 
@@ -119,14 +119,14 @@ highly optimised for this, so bit syntax is highly efficient too!
 For example, if I wanted to create a 32 bit unsigned little endian integer
 with the value of 100 I could do so using bit syntax like this:
 
-```rust
+```gleam
 let my_integer = <<100:unsigned-little-int-size(32)>>
 ```
 
 Or if I wanted to extract the title, artist, album, year, and comment from an
 MP3 music file's ID3 tags I could pattern match on it like this:
 
-```rust
+```gleam
 pub fn get_metadata(id3: BitString) -> Result(Metadata, String) {
   case id3 {
     <<

--- a/_posts/2020-08-28-gleam-v0.11-released.md
+++ b/_posts/2020-08-28-gleam-v0.11-released.md
@@ -16,7 +16,7 @@ Previously when we wanted to update some of the fields on the record we would
 need to create a new instance and manually copy across the fields that have
 not changed.
 
-```rust
+```gleam
 pub fn level_up(pokemon: Pokemon) {
   let new_level = pokemon.level + 1
   let new_moves = moves_for(pokemon.species, new_level)
@@ -37,7 +37,7 @@ To remedy this problem [Quinn Wilton](https://github.com/QuinnWilton) has
 added the record update syntax to Gleam, so now we only need to specify the
 fields that change.
 
-```rust
+```gleam
 pub fn level_up(pokemon: Pokemon) {
   let new_level = pokemon.level + 1
   let new_moves = moves_for(pokemon.species, new_level)
@@ -57,7 +57,7 @@ Gleam's numbers.
 
 There's now syntaxes for binary, octal, and hexadecimal int literals.
 
-```rust
+```gleam
 // 4 ways of writing the int 15
 let hexadecimal = 0xF
 let decimal = 15
@@ -73,7 +73,7 @@ These might be handy in many situations such as when implementing
 
 Underscores can now be added to numbers, making larger numbers easier to read.
 
-```rust
+```gleam
 let billion = 1_000_000_000
 let trillion_and_change = 1_000_000_000_000.57
 ```
@@ -86,7 +86,7 @@ Type holes can be used to give partial annotations to values.
 Here we're saying that `x` is a List, but we're not saying what type the list
 contains, leaving the compiler to infer it.
 
-```rust
+```gleam
 let x: List(_) = run()
 ```
 
@@ -104,7 +104,7 @@ The formatter style has been improved in several ways, and the performance of
 the formatter has been improved. One popular change is to how it formats
 assignments that don't fit on a single line.
 
-```rust
+```gleam
 // Before
 assert Ok(
   tuple(user, session),
@@ -142,7 +142,7 @@ HTTP library.
 
 Here's a simplistic service that echoes back any body sent to it.
 
-```rust
+```gleam
 import gleam/http.{Request}
 
 pub fn echo_service(request: Request(_)) {
@@ -154,7 +154,7 @@ pub fn echo_service(request: Request(_)) {
 As a normal Gleam function it is easy to test this service, no special test
 helpers or test server are required.
 
-```rust
+```gleam
 import gleam/should
 import my_app
 
@@ -175,7 +175,7 @@ pub fn echo_test() {
 Gleam's HTTP library also provides middleware, which can be used to add
 additional functionality to a HTTP service.
 
-```rust
+```gleam
 import gleam/bit_builder
 import gleam/http/middleware
 
@@ -198,7 +198,7 @@ HTTP server adapter, such as one for the [Elli Erlang web server][elli].
 
 [elli]: https://github.com/elli-lib/elli
 
-```rust
+```gleam
 import my_app
 import gleam/http/elli
 
@@ -212,7 +212,7 @@ Or one for the [Cowboy Erlang web server][cowboy].
 [cowboy]: https://github.com/ninenines/cowboy
 
 
-```rust
+```gleam
 import my_app
 import gleam/http/cowboy
 
@@ -252,7 +252,7 @@ includes all the above as well as other concepts such as routing and logging.
 HTTP services are only half the story! We also can use the HTTP library to
 make out own requests.
 
-```rust
+```gleam
 import gleam/http
 import gleam/httpc
 

--- a/_posts/2020-10-31-gleam-v0.12-and-gleam-otp-v0.1-released.md
+++ b/_posts/2020-10-31-gleam-v0.12-and-gleam-otp-v0.1-released.md
@@ -15,7 +15,7 @@ actor system][gleam-otp], compatible with Erlang's OTP.
 
 Historically functions in Gleam had to be defined in a module prior to being used.
 
-```rust
+```gleam
 pub fn main() {
   helper() // Compile error! Function `helper` not found
 }
@@ -43,7 +43,7 @@ useful techniques such as mutual recursion impossible.
 With this release statements in a module can be written in any order, and
 they still don't require any type annotations to be fully type checked.
 
-```rust
+```gleam
 pub fn barry() {
   io.println("To you!")
   paul()
@@ -98,7 +98,7 @@ provides functions for creating and working with them.
 
 [docs-process]: https://hexdocs.pm/gleam_otp/0.1.1/gleam/otp/process/
 
-```rust
+```gleam
 import gleam/io
 import gleam/otp/process
 
@@ -147,7 +147,7 @@ channel owner process.
 [docs-sender]: https://hexdocs.pm/gleam_otp/0.1.1/gleam/otp/process/#Sender
 [docs-receiver]: https://hexdocs.pm/gleam_otp/0.1.1/gleam/otp/process/#Receiver
 
-```rust
+```gleam
 import gleam/io
 import gleam/otp/process
 
@@ -192,7 +192,7 @@ differs in design to `gen_server` in order to provide type safety.
 
 [docs-actor]: https://hexdocs.pm/gleam_otp/0.1.1/gleam/otp/actor/
 
-```rust
+```gleam
 import gleam/io
 import gleam/otp/actor
 import gleam/otp/process.{Sender}
@@ -250,7 +250,7 @@ self-heals. This is kind-of similar to how Kubernetes and other container
 orchestrators handle failure in microservices, though faster and more precise
 thanks to it being integrated at all levels of the program.
 
-```rust
+```gleam
 import gleam/otp/supervisor.{add, returning, worker}
 import my_app/monitoring
 import my_app/database

--- a/_posts/2021-01-13-gleam-v0.13-released.md
+++ b/_posts/2021-01-13-gleam-v0.13-released.md
@@ -361,7 +361,7 @@ future.
 
 In Gleam dividing by zero returns zero!
 
-```rust
+```gleam
 1337 / 0 // => 0
 ```
 

--- a/_posts/2021-02-18-gleam-v0.14-released.md
+++ b/_posts/2021-02-18-gleam-v0.14-released.md
@@ -27,7 +27,7 @@ using Gleam alongside Elixir or Erlang.
 
 For a quick example, here's some code in Gleam:
 
-```rust
+```gleam
 pub type LinkedList(element) {
   Empty
   Node(element, LinkedList(element))

--- a/_posts/2021-05-06-gleam-v0.15-released.md
+++ b/_posts/2021-05-06-gleam-v0.15-released.md
@@ -16,7 +16,7 @@ highlights.
 A common bugbear of Gleam developers so far has been that the tuple literal
 syntax is rather verbose.
 
-```rust
+```gleam
 pub fn main() -> tuple(Int, Float, String) {
   tuple(1, 2.0, "three")
 }
@@ -28,7 +28,7 @@ of popular programming languages such as Python, Rust, and Haskell.
 
 [discord]: https://discord.gg/Fm8Pwmy
 
-```rust
+```gleam
 pub fn main() -> #(Int, Float, String) {
   #(1, 2.0, "three")
 }
@@ -52,7 +52,7 @@ This proved a problem in situations where a module defines a new type or value
 constructor with the same name as one of the items from the prelude, as it would
 no longer be possible to refer to the prelude one.
 
-```rust
+```gleam
 pub type TuringBool {
   True  // Bool's True being shadowed
   False // Bool's False being shadowed
@@ -71,7 +71,7 @@ pub fn is_problem_solvable() -> Bool {
 Now with v0.15.0 the prelude module can be imported using the name `gleam`,
 enabling qualified use of prelude items.
 
-```rust
+```gleam
 import gleam
 
 // ...
@@ -92,7 +92,7 @@ The first is an development ergonomics issue. When writing Gleam code it is
 often desirable to save as often as possible so that the type checker can inform
 you of any mistakes or inconsistencies in the code that has just been written.
 
-```rust
+```gleam
 pub fn main() {
   let x = run(1, 2, 3)
   // And now I've hit save...
@@ -114,7 +114,7 @@ The next issue is that previously it was not possible to have an assertion as
 the final form in a function or block, forcing the user to add a superfluous
 dummy value to be returned.
 
-```rust
+```gleam
 /// A function that asserts `segments` is non-empty and
 /// starts with a slash.
 pub fn assert_valid(segments) {

--- a/book-src/tour/custom-types.md
+++ b/book-src/tour/custom-types.md
@@ -109,7 +109,7 @@ using `.field_name`.
 
 For example using the `Cat` type defined earlier.
 
-```rust
+```gleam
 let cat = Cat(name: "Nubi", cuteness: 2001)
 cat.name // This returns "Nubi"
 cat.cuteness // This returns 2001

--- a/cheatsheets/gleam-for-elixir-users.md
+++ b/cheatsheets/gleam-for-elixir-users.md
@@ -54,13 +54,13 @@ In Elixir comments are written with a `#` prefix.
 
 In Gleam comments are written with a `//` prefix.
 
-```rust
+```gleam
 // Hello, Joe!
 ```
 
 Comments starting with `///` are used to document the following statement. Comments starting with `////` are used to document the current module.
 
-```rust
+```gleam
 //// This module is very important.
 
 /// The answer to life, the universe, and everything.
@@ -83,7 +83,7 @@ size = 1
 
 Gleam has the `let` keyword before its variable names.
 
-```rust
+```gleam
 let size = 50
 let size = size + 100
 let size = 1
@@ -103,7 +103,7 @@ let size = 1
 
 In Gleam, `let` and `=` can be used for pattern matching, but you'll get compile errors if there's a type mismatch, and a runtime error if there's a value mismatch. For assertions, the equivalent `assert` keyword is preferred.
 
-```rust
+```gleam
 let [x] = [1]
 assert 2 = x // runtime error
 assert [y] = "Hello" // compile error, type mismatch
@@ -123,7 +123,7 @@ some_list = [1, 2, 3]
 
 In Gleam type annotations can optionally be given when binding variables.
 
-```rust
+```gleam
 let some_list: List(Int) = [1, 2, 3]
 ```
 
@@ -149,7 +149,7 @@ mul.(1, 2)
 
 Gleam's functions are declared using a syntax similar to Rust or JavaScript. Gleam's anonymous functions have a similar syntax and don't need a `.` when called.
 
-```rust
+```gleam
 pub fn sum(x, y) {
   x + y
 }
@@ -180,7 +180,7 @@ end
 
 In Gleam functions are private by default and need the `pub` keyword to be public.
 
-```rust
+```gleam
 // this is public
 pub fn sum(x, y) {
   x + y
@@ -210,7 +210,7 @@ def mul(x, y), do: x * y
 
 Functions can **optionally** have their argument and return types annotated in Gleam. These type annotations will always be checked by the compiler and throw a compilation error if not valid. The compiler will still type check your program using type inference if annotations are omitted.
 
-```rust
+```gleam
 pub fn add(x: Int, y: Int) -> Int {
   x + y
 }
@@ -235,7 +235,7 @@ def zero?(x), do: false
 
 Gleam functions can have only one function head. Use a case expression to pattern match on function arguments.
 
-```rust
+```gleam
 pub fn is_zero(x) { // we cannot use `?` in function names in Gleam
   case x {
     0 -> true
@@ -268,7 +268,7 @@ end
 ```
 
 #### Gleam
-```rust
+```gleam
 fn identity(x) {
   x
 }
@@ -296,7 +296,7 @@ mod_function(3, 4)
 
 #### Gleam
 
-```rust
+```gleam
 let my_function = fn(x, y) { x + y }
 anon_function(1, 2)
 mod_function(3, 4)
@@ -339,7 +339,7 @@ In Gleam arguments can be given a label as well as an internal name. As with
 Elixir the name used at the call-site does not have to match the name used
 for the variable inside the function.
 
-```rust
+```gleam
 pub fn replace(inside string, each pattern, with replacement) {
   go(string, pattern, replacement)
 }
@@ -401,7 +401,7 @@ end
 
 In Gleam constants can be created using the `const` keyword.
 
-```rust
+```gleam
 const the_answer = 42
 
 pub fn main() {
@@ -411,12 +411,12 @@ pub fn main() {
 
 Additionally, Gleam constants can be referenced from other modules.
 
-```rust
+```gleam
 // in file other_module.gleam
 pub const the_answer: Int = 42
 ```
 
-```rust
+```gleam
 import other_module
 
 fn main() {
@@ -448,7 +448,7 @@ end
 
 In Gleam braces `{` `}` are used to group expressions.
 
-```rust
+```gleam
 pub fn main() {
   let x = {
     print(1)
@@ -474,7 +474,7 @@ In both Elixir and Gleam all strings are UTF-8 encoded binaries.
 
 #### Gleam
 
-```rust
+```gleam
 "Hellø, world!"
 ```
 
@@ -491,7 +491,7 @@ my_tuple = {"username", "password", 10}
 
 #### Gleam
 
-```rust
+```gleam
 let my_tuple = #("username", "password", 10)
 let #(_, password, _) = my_tuple
 ```
@@ -513,7 +513,7 @@ list = [1 | list]
 
 #### Gleam
 
-```rust
+```gleam
 let list = [2, 3, 4]
 let list = [1, ..list]
 let [1, second_element, ..] = list
@@ -540,7 +540,7 @@ var = :my_new_var
 
 #### Gleam
 
-```rust
+```gleam
 type MyNewType {
   MyNewVar
 }
@@ -566,7 +566,7 @@ There is no map literal syntax in Gleam, and you cannot pattern match on a map. 
 
 #### Gleam
 
-```rust
+```gleam
 import gleam/map
 
 map.from_list([#("key1", "value1"), #("key2", "value2")])
@@ -606,7 +606,7 @@ require Person
 
 Gleam's custom types can be used in much the same way that structs are used in Elixir. At runtime, they have a tuple representation and are compatible with Erlang records.
 
-```rust
+```gleam
 type Person {
   Person(name: String, age: Int)
 }
@@ -639,14 +639,14 @@ end
 
 Gleam's file is a module and named by the file name (and its directory path). Since there is no special syntax to create a module, there can be only one module in a file.
 
-```rust
+```gleam
 // in file foo.gleam
 pub fn identity(x) {
   x
 }
 ```
 
-```rust
+```gleam
 // in file main.gleam
 import foo // if foo was in a folder called `lib` the import would be `lib/foo`
 pub fn main() {

--- a/cheatsheets/gleam-for-elm-users.md
+++ b/cheatsheets/gleam-for-elm-users.md
@@ -76,13 +76,13 @@ length xs =
 
 In Gleam comments are written with a `//` prefix.
 
-```rust
+```gleam
 // Hello, Joe!
 ```
 
 Comments starting with `///` are used to document the following function, constant, or type definition. Comments starting with `////` are used to document the current module.
 
-```rust
+```gleam
 //// This module is very important.
 
 /// The answer to life, the universe, and everything.
@@ -110,7 +110,7 @@ in
 
 Gleam has the `let` keyword before its variable names. You can re-assign variables and you can shadow variables from other scopes. This does not mutate the previously assigned value.
 
-```rust
+```gleam
 let size = 50
 let size = size + 100
 let size = 1
@@ -133,7 +133,7 @@ someList = [1, 2, 3]
 
 In Gleam type annotations can optionally be given when binding variables.
 
-```rust
+```gleam
 let some_list: List(Int) = [1, 2, 3]
 ```
 
@@ -155,7 +155,7 @@ theAnswer =
 
 In Gleam constants can be created using the `const` keyword.
 
-```rust
+```gleam
 const the_answer = 42
 
 pub fn main() {
@@ -165,12 +165,12 @@ pub fn main() {
 
 Gleam constants can be referenced from other modules.
 
-```rust
+```gleam
 // in file other_module.gleam
 pub const the_answer: Int = 42
 ```
 
-```rust
+```gleam
 import other_module
 
 fn main() {
@@ -199,7 +199,7 @@ mul 3 2
 
 Gleam's functions are declared using a syntax similar to Rust or JavaScript. Gleam's anonymous functions are declared using the `fn` keyword.
 
-```rust
+```gleam
 pub fn sum(x, y) {
   x + y
 }
@@ -227,7 +227,7 @@ mul x y = x * y
 
 All the same things are true of Gleam though the type annotations go inline in the function declaration, rather than above it.
 
-```rust
+```gleam
 pub fn add(x: Int, y: Int) -> Int {
   x + y
 }
@@ -264,7 +264,7 @@ replace { defaultOptions | inside = "A,B,C,D" }
 
 In Gleam arguments can be given a label as well as an internal name.
 
-```rust
+```gleam
 pub fn replace(inside string, each pattern, with replacement) {
   go(string, pattern, replacement)
 }
@@ -295,14 +295,14 @@ identity x =
 
 A Gleam file is a module, named by the file name (and its directory path). There is no special syntax to create a module. There can be only one module in a file.
 
-```rust
+```gleam
 // in file foo.gleam
 pub fn identity(x) {
   x
 }
 ```
 
-```rust
+```gleam
 // in file main.gleam
 import foo // if foo was in a folder called `lib` the import would be `lib/foo`
 pub fn main() {
@@ -332,7 +332,7 @@ mul x y =
 
 In Gleam, constants & functions are private by default and need the `pub` keyword to be public.
 
-```rust
+```gleam
 // this is public
 pub fn sum(x, y) {
   x + y
@@ -369,7 +369,7 @@ end
 
 In Gleam braces `{` `}` are used to group expressions.
 
-```rust
+```gleam
 pub fn main() {
   let x = {
     print(1)
@@ -396,7 +396,7 @@ Operators in Gleam as not generic over `Int` and `Float` so there are separate s
 
 Additionally, underscores can be added to both integers and floats for clarity.
 
-```rust
+```gleam
 const oneMillion = 1_000_000
 const twoMillion = 2_000_000.0
 ```
@@ -428,13 +428,13 @@ holidayWishes =
 
 #### Gleam
 
-```rust
+```gleam
 "Hellø, world!"
 ```
 
 Gleam does not have an operator for combining strings. Like Elm, it has [`string.append`](https://hexdocs.pm/gleam_stdlib/gleam/string/#append) and [`string.concat`](https://hexdocs.pm/gleam_stdlib/gleam/string/#concat) in the standard library.
 
-```rust
+```gleam
 birthdayWishes = string.append(to: "Happy Birthday ", suffix: person.name)
 
 holidayWishes = string.concat([ "Happy ", holiday.name, person.name ])
@@ -457,7 +457,7 @@ myTuple = ("username", "password", 10)
 
 There is no limit to the number of entries in Gleam tuples, but records are still recommended as giving names to fields adds clarity.
 
-```rust
+```gleam
 let my_tuple = #("username", "password", 10)
 let #(_, password, _) = my_tuple
 ```
@@ -502,7 +502,7 @@ let person = Person(name: "Alice", age: 43)
 
 Record fields can be accessed with a dot syntax:
 
-```rust
+```gleam
 greeting = String.concat(["Hello, ",  person.name, "!"])
 ```
 
@@ -524,7 +524,7 @@ yetAnotherList = "hello" :: list // compile error, type mismatch
 
 Gleam also has a built-in syntax for lists and its own spread operator (`..`) for adding elements to the front of a list.
 
-```rust
+```gleam
 let list = [2, 3, 4]
 let list = [1, ..list]
 let another_list = [1.0, ..list] // compile error, type mismatch
@@ -551,7 +551,7 @@ Dict.fromList [ ("key1", "value1"), ("key2", 2) ] -- Compile error
 
 #### Gleam
 
-```rust
+```gleam
 import gleam/map
 
 map.from_list([#("key1", "value1"), #("key2", "value2")])
@@ -610,7 +610,7 @@ name = person.name
 
 Gleam's custom types can be used in much the same way. At runtime, they have a tuple representation and are compatible with Erlang records.
 
-```rust
+```gleam
 type Person {
   Person(name: String, age: Int)
 }
@@ -651,7 +651,7 @@ A custom type with a single entry can be used to help create opaque data types f
 
 #### Gleam
 
-```rust
+```gleam
 type User {
   LoggedIn(name: String)  // A logged in user with a name
   Guest                   // A guest user with no details
@@ -660,7 +660,7 @@ type User {
 
 Like in Elm, you must use a case-expression to interact with the contents of a value that uses a custom type.
 
-```rust
+```gleam
 fn get_name(user) {
   case user {
     LoggedIn(name) -> name
@@ -692,7 +692,7 @@ type Maybe a
 
 In Gleam, `Option` is defined as:
 
-```rust
+```gleam
 pub type Option(a) {
   Some(a)
   None
@@ -721,7 +721,7 @@ In Gleam, the `Result` type is defined in the compiler in order to support helpf
 
 If it were defined in Gleam, it would look like this:
 
-```rust
+```gleam
 pub type Result(value, reason) {
   Ok(value)
   Error(reason)
@@ -751,7 +751,7 @@ description =
 
 Gleam has no built in if-expression syntax and instead relies on matching on boolean values in case-expressions to provide this functionality:
 
-```rust
+```gleam
 let description =
   case value {
     True -> "It's true!"
@@ -780,7 +780,7 @@ getName user =
 
 #### Gleam
 
-```rust
+```gleam
 fn get_name(user) {
   case user {
     LoggedIn(name) -> name
@@ -791,7 +791,7 @@ fn get_name(user) {
 
 Pattern matching on multiple values at the same time is supported:
 
-```rust
+```gleam
 case x, y {
   1, 1 -> "both are 1"
   1, _ -> "x is 1"
@@ -803,7 +803,7 @@ case x, y {
 Guard expressions can also be used to limit when certain patterns are matched:
 
 
-```rust
+```gleam
 case xs {
   [a, b, c] if a == b && b != c -> "ok"
   _other -> "ko"
@@ -838,7 +838,7 @@ Functions that call Erlang code directly use the `external` keyword and use stri
 It is possible to call functions provided by other languages on the Erlang Virtual Machine but only via the Erlang name that those functions end up with.
 
 
-```rust
+```gleam
 pub external fn random_float() -> Float = "rand" "uniform"
 
 // Elixir modules start with `Elixir.`
@@ -902,7 +902,7 @@ type Alignment
 
 #### Gleam
 
-```rust
+```gleam
 type Alignment {
   Left
   Centre

--- a/cheatsheets/gleam-for-erlang-users.md
+++ b/cheatsheets/gleam-for-erlang-users.md
@@ -58,7 +58,7 @@ Size2 = 1 % Runtime error! Size2 is 150, not 1
 In Gleam variables are written with a lowercase letter, and names can be
 reassigned.
 
-```rust
+```gleam
 let size = 50
 let size = size + 100
 let size = 1 // size now refers to 1
@@ -80,7 +80,7 @@ used to assert that a given term has a specific shape.
 In Gleam the `assert` keyword is used to make assertions using partial
 patterns.
 
-```rust
+```gleam
 let [element] = some_list // Compile error! Partial pattern
 assert [element] = some_list
 ```
@@ -95,7 +95,7 @@ In Erlang it's not possible to give type annotations to variables.
 
 In Gleam type annotations can optionally be given when binding variables.
 
-```rust
+```gleam
 let some_list: List(Int) = [1, 2, 3]
 ```
 
@@ -118,7 +118,7 @@ my_function(X) ->
 ```
 
 #### Gleam
-```rust
+```gleam
 fn my_function(x) {
   x + 1
 }
@@ -138,7 +138,7 @@ my_function(X) ->
 ```
 
 #### Gleam
-```rust
+```gleam
 pub fn my_function(x) {
   x + 1
 }
@@ -156,7 +156,7 @@ my_function(X) ->
 ```
 
 #### Gleam
-```rust
+```gleam
 fn my_function(x: Int) -> Int {
   x + 1
 }
@@ -184,7 +184,7 @@ identify(_) ->
 ```
 
 #### Gleam
-```rust
+```gleam
 fn identify(x) {
   case x {
     1 -> "one"
@@ -218,7 +218,7 @@ main() ->
 ```
 
 #### Gleam
-```rust
+```gleam
 fn identity(x) {
   x
 }
@@ -242,7 +242,7 @@ without adding parenthesis around the function call.
 
 #### Gleam
 
-```rust
+```gleam
 some_function(0)(1)(2)(3)
 ```
 
@@ -278,7 +278,7 @@ In Gleam arguments can be given a label as well as an internal name. As with
 Erlang the name used at the call-site does not have to match the name used
 for the variable inside the function.
 
-```rust
+```gleam
 pub fn replace(inside string, each pattern, with replacement) {
   go(string, pattern, replacement)
 }
@@ -306,14 +306,14 @@ In Erlang comments are written with a `%` prefix.
 
 In Gleam comments are written with a `//` prefix.
 
-```rust
+```gleam
 // Hello, Joe!
 ```
 
 Comments starting with `///` are used to document the following statement,
 comments starting with `////` are used to document the current module.
 
-```rust
+```gleam
 //// This module is very important.
 
 /// The answer to life, the universe, and everything.
@@ -363,7 +363,7 @@ ledger:from_list(X2).
 ```
 
 #### Gleam
-```rust
+```gleam
 input
 |> trim
 |> csv.parse(",")
@@ -389,7 +389,7 @@ main() ->
 
 In Gleam constants can be used to achieve the same.
 
-```rust
+```gleam
 const the_answer = 42
 
 fn main() {
@@ -399,7 +399,7 @@ fn main() {
 
 Gleam constants can be referenced from other modules.
 
-```rust
+```gleam
 import other_module
 
 fn main() {
@@ -427,7 +427,7 @@ main() ->
 
 In Gleam braces are used to group expressions.
 
-```rust
+```gleam
 fn main() {
   let x = {
     print(1)
@@ -452,7 +452,7 @@ All strings in Gleam are UTF-8 encoded binaries.
 
 #### Gleam
 
-```rust
+```gleam
 "Hellø, world!"
 ```
 
@@ -470,7 +470,7 @@ Tuple = {"username", "password", 10}.
 
 #### Gleam
 
-```rust
+```gleam
 let my_tuple = #("username", "password", 10)
 let #(_, password, _) = my_tuple
 ```
@@ -494,7 +494,7 @@ List1 = [1 | List0].
 
 #### Gleam
 
-```rust
+```gleam
 let list = [2, 3, 4]
 let list = [1, ..list]
 let [1, second_element, ..] = list
@@ -525,7 +525,7 @@ Var = my_new_var.
 
 #### Gleam
 
-```rust
+```gleam
 type MyNewType {
   MyNewVar
 }
@@ -554,7 +554,7 @@ not used much in Gleam, custom types are more common.
 
 #### Gleam
 
-```rust
+```gleam
 import gleam/map
 
 
@@ -586,7 +586,7 @@ TODO
 
 #### Gleam
 
-```rust
+```gleam
 pub type Scores =
   List(Int)
 ```
@@ -617,12 +617,12 @@ Name = #Person.name.
 
 #### Gleam
 
-```rust
+```gleam
 type Person {
   Person(age: Int, name: String)
 }
 ```
-```rust
+```gleam
 let person = Person(name: "name", age: 35)
 let name = person.name
 ```
@@ -647,7 +647,7 @@ int_or_float(X) ->
 
 #### Gleam
 
-```rust
+```gleam
 type IntOrFloat {
   AnInt(Int)
   AFloat(Float)
@@ -683,7 +683,7 @@ get_id() ->
 ```
 
 #### Gleam
-```rust
+```gleam
 pub opaque type Identifier {
   Identifier(Int)
 }

--- a/cheatsheets/gleam-for-python-users.md
+++ b/cheatsheets/gleam-for-python-users.md
@@ -58,13 +58,13 @@ def a_method():
 
 In Gleam, comments are written with a `//` prefix.
 
-```rust
+```gleam
 // Hello, Joe!
 ```
 
 Comments starting with `///` are used to document the following statement. Comments starting with `////` are used to document the current module.
 
-```rust
+```gleam
 //// This module is very important.
 
 /// The answer to life, the universe, and everything.
@@ -89,7 +89,7 @@ Python has no specific variable keyword. You choose a name and that's it!
 
 Gleam has the `let` keyword before its variable names.
 
-```rust
+```gleam
 let size = 50
 let size = size + 100
 let size = 1
@@ -116,7 +116,7 @@ for key, value in enumerate(a_dict):
 
 In Gleam, `let` and `=` can be used for pattern matching, but you'll get compile errors if there's a type mismatch, and a runtime error if there's a value mismatch. For assertions, the equivalent `assert` keyword is preferred.
 
-```rust
+```gleam
 let #(x, _) = #(1, 2)
 assert [] = [1] // runtime error
 assert [y] = "Hello" // compile error, type mismatch
@@ -143,7 +143,7 @@ some_list: List[int] = [1, 2, 3]
 
 In Gleam type annotations can optionally be given when binding variables.
 
-```rust
+```gleam
 let some_list: List(Int) = [1, 2, 3]
 ```
 
@@ -171,7 +171,7 @@ mul(1, 2)
 
 Gleam's functions are declared using a syntax similar to Rust or JavaScript. Gleam's anonymous functions have a similar syntax and don't need a `.` when called.
 
-```rust
+```gleam
 pub fn sum(x, y) {
   x + y
 }
@@ -190,7 +190,7 @@ In Python, top level functions are exported by default. There is no notion of pr
 
 In Gleam, functions are private by default and need the `pub` keyword to be public.
 
-```rust
+```gleam
 // this is public
 pub fn sum(x, y) {
   x + y
@@ -225,7 +225,7 @@ def mul(x: int, y: int) -> bool:
 
 Functions can **optionally** have their argument and return types annotated in Gleam. These type annotations will always be checked by the compiler and throw a compilation error if not valid. The compiler will still type check your program using type inference if annotations are omitted.
 
-```rust
+```gleam
 pub fn add(x: Int, y: Int) -> Int {
   x + y
 }
@@ -246,7 +246,7 @@ As long as functions are in scope they can be assigned to a new variable. There 
 Gleam has a single namespace for value and functions within a module, so there
 is no need for a special syntax to assign a module function to a variable.
 
-```rust
+```gleam
 fn identity(x) {
   x
 }
@@ -284,7 +284,7 @@ replace(each='world', inside='hello world',  with_string='you')
 In Gleam arguments can be given a label as well as an internal name. Contrary to Python, the name used at the call-site does not have to match the name used
 for the variable inside the function.
 
-```rust
+```gleam
 pub fn replace(inside string, each pattern, with replacement) {
   go(string, pattern, replacement)
 }
@@ -361,7 +361,7 @@ the_answer = 42
 
 In Gleam constants can be created using the `const` keyword.
 
-```rust
+```gleam
 const the_answer = 42
 
 pub fn main() {
@@ -387,7 +387,7 @@ def a_func():
 
 In Gleam braces `{` `}` are used to group expressions.
 
-```rust
+```gleam
 pub fn main() {
   let x = {
     some_function(1)
@@ -414,7 +414,7 @@ In Gleam all strings are UTF-8 encoded binaries.
 
 #### Gleam
 
-```rust
+```gleam
 "Hellø, world!"
 ```
 
@@ -433,7 +433,7 @@ _, password, _ = my_tuple
 
 #### Gleam
 
-```rust
+```gleam
 let my_tuple = #("username", "password", 10)
 let #(_, password, _) = my_tuple
 ```
@@ -457,7 +457,7 @@ list = [2, 3, 4]
 
 Gleam has a `cons` operator that works for lists destructuring and pattern matching. In Gleam lists are immutable so adding and removing elements from the start of a list is highly efficient.
 
-```rust
+```gleam
 let list = [2, 3, 4]
 let list = [1, ..list]
 let [1, second_element, ..] = list
@@ -485,7 +485,7 @@ There is no map literal syntax in Gleam, and you cannot pattern match on a map. 
 
 #### Gleam
 
-```rust
+```gleam
 import gleam/map
 
 map.from_list([#("key1", "value1"), #("key2", "value2")])
@@ -565,7 +565,7 @@ match point:
 
 The case operator is a top level construct in Gleam:
 
-```rust
+```gleam
 case some_number {
   0 -> "Zero"
   1 -> "One"
@@ -576,7 +576,7 @@ case some_number {
 
 The case operator especially coupled with destructuring to provide native pattern matching:
 
-```rust
+```gleam
 case xs {
   [] -> "This list is empty"
   [a] -> "This list has 1 element"
@@ -596,7 +596,7 @@ case xs {
 
 and disjoint union matching:
 
-```rust
+```gleam
 case number {
   2 | 4 | 6 | 8 -> "This is an even number"
   1 | 3 | 5 | 7 -> "This is an odd number"
@@ -644,7 +644,7 @@ A Result is either:
 
 Handling errors actually means to match the return value against those two scenarios, using a case for instance:
 
-```rust
+```gleam
 case parse_int("123") {
   Error(e) -> io.println("That wasn't an Int")
   Ok(i) -> io.println("We parsed the Int")
@@ -656,7 +656,7 @@ In order to simplify this construct, we can use the `try` keyword that will:
 - bind a value to the providing name if Ok(Something) is matched
 - **interrupt the flow** and return `Error(Something)`
 
-```rust
+```gleam
 let a_number = "1"
 let an_error = Error("ouch")
 let another_number = "3"
@@ -689,7 +689,7 @@ tensor: Vector = [1.0, 2.0, 3.0]
 
 The `type` keyword can be used to create aliases
 
-```rust
+```gleam
 pub type Headers =
   List(#(String, String))
 ```
@@ -742,7 +742,7 @@ person.name = "John" # error
 
 Gleam's custom types can be used in much the same way that structs are used in Elixir. At runtime, they have a tuple representation and are compatible with Erlang records.
 
-```rust
+```gleam
 type Person {
   Person(name: String, age: Int)
 }
@@ -770,7 +770,7 @@ OptionalString = Union[str, None]
 
 #### Gleam
 
-```rust
+```gleam
 type IntOrFloat {
   AnInt(Int)
   AFloat(Float)
@@ -812,7 +812,7 @@ class OnlyCreatable(object):
 
 #### Gleam
 
-```rust
+```gleam
 pub opaque type Identifier {
   Identifier(Int)
 }
@@ -832,14 +832,14 @@ There is no special syntax to define modules as files are modules in Python
 
 Gleam's file is a module and named by the file name (and its directory path). Since there is no special syntax to create a module, there can be only one module in a file.
 
-```rust
+```gleam
 // in file foo.gleam
 pub fn identity(x) {
   x
 }
 ```
 
-```rust
+```gleam
 // in file main.gleam
 import foo // if foo was in a folder called `lib` the import would be `lib/foo`
 pub fn main() {
@@ -865,7 +865,7 @@ Imports are relative to the root `src` folder.
 
 Modules in the same directory will need to reference the entire path from `src` for the target module, even if the target module is in the same folder.
 
-```rust
+```gleam
 // inside src/nasa/moon_base.gleam
 // imports src/nasa/rocket_ship.gleam
 import nasa/rocket_ship
@@ -885,7 +885,7 @@ import unix.cat as kitty
 
 #### Gleam
 
-```rust
+```gleam
 import unix/cat
 import animal/cat as kitty
 ```
@@ -900,7 +900,7 @@ from animal.cat import Cat, stroke
 
 #### Gleam
 
-```rust
+```gleam
 import animal/cat.{Cat, stroke}
 
 pub fn main() {

--- a/cheatsheets/gleam-for-rust-users.md
+++ b/cheatsheets/gleam-for-rust-users.md
@@ -60,13 +60,13 @@ const answer: u64 = 42;
 
 In Gleam comments are written with a `//` prefix.
 
-```rust
+```gleam
 // Hello, Joe!
 ```
 
 Comments starting with `///` are used to document the following statement. Comments starting with `////` are used to document the current module.
 
-```rust
+```gleam
 //// This module is very important.
 
 /// The answer to life, the universe, and everything.
@@ -87,7 +87,7 @@ let size = 1;
 
 #### Gleam
 
-```rust
+```gleam
 let size = 50
 let size = size + 100
 let size = 1
@@ -111,7 +111,7 @@ let [y] = "Hello"; // compile error, type mismatch
 
 In Gleam, `let` and `=` can also be used for pattern matching, but you'll get compile errors if there's a type mismatch, and a runtime error if there's a value mismatch. For assertions, the equivalent `assert` keyword is preferred.
 
-```rust
+```gleam
 let [x] = [1]
 assert 2 = x // runtime error
 assert [y] = "Hello" // compile error, type mismatch
@@ -130,7 +130,7 @@ let other_list = [1, 2, 3];
 
 #### Gleam
 
-```rust
+```gleam
 let some_list: List(Int) = [1, 2, 3]
 let other_list = [1, 2, 3]
 ```
@@ -152,7 +152,7 @@ mul(1, 2);
 
 Gleam's functions are declared using a syntax similar to Rust's. Anonymous functions are a bit different from Rust, using the `fn` keyword again.
 
-```rust
+```gleam
 pub fn sum(x, y) {
   x + y
 }
@@ -181,7 +181,7 @@ fn mul(x: u64, y: u64) -> u64 {
 
 #### Gleam
 
-```rust
+```gleam
 // this is public
 pub fn sum(x, y) {
   x + y
@@ -213,7 +213,7 @@ pub fn mul(x: u64, y: u64) -> u64 {
 
 Functions can **optionally** have their argument and return types annotated in Gleam. These type annotations will always be checked by the compiler and throw a compilation error if not valid. The compiler will still type check your program using type inference if annotations are omitted.
 
-```rust
+```gleam
 pub fn add(x: Int, y: Int) -> Int {
   x + y
 }
@@ -248,7 +248,7 @@ fn main() {
 
 #### Gleam
 
-```rust
+```gleam
 fn identity(x) {
   x
 }
@@ -339,7 +339,7 @@ fn main() {
 
 In Gleam constants can be created using the `const` keyword, and can be optionally given a type annotation.
 
-```rust
+```gleam
 const the_answer = 42
 
 pub fn main() {
@@ -380,7 +380,7 @@ let y = x * (x + 10); // parenthesis are used to change arithmetic operations or
 
 In Gleam braces `{` `}` are used to group both expressions and arithmetic operations.
 
-```rust
+```gleam
 let x = {
   print(1)
   2
@@ -402,7 +402,7 @@ In both Rust and Gleam all strings are UTF-8 encoded binaries.
 
 #### Gleam
 
-```rust
+```gleam
 "Hellø, world!"
 ```
 
@@ -419,7 +419,7 @@ let (_, password, _) = my_tuple;
 
 Tuples are very useful in Gleam as they're the only collection data type that allows mixed types in the collection.
 
-```rust
+```gleam
 let my_tuple = #("username", "password", 10)
 let #(_, password, _) = my_tuple
 ```
@@ -441,7 +441,7 @@ let [0, second_element, ..] = list; // Compile error!
 
 The `cons` operator works the same way both for pattern matching and for appending elements to the head of a list.
 
-```rust
+```gleam
 let list = [1, 2, 3]
 let list = [0, ..list]
 let [0, second_element, ..] = list
@@ -473,7 +473,7 @@ let name = person.name;
 
 Gleam's custom types can be declared using the `type` keyword. At runtime, they have a tuple representation and are compatible with Erlang records.
 
-```rust
+```gleam
 type Person {
   Person(name: String, age: Int)
 }
@@ -512,7 +512,7 @@ In Gleam, each file is a module, named by the file name (and its directory path)
 
 Gleam uses the `import` keyword to import modules, and the dot `.` operator to access properties and functions inside.
 
-```rust
+```gleam
 // in file foo.gleam
 pub fn identity(x) {
   x

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@ list_sponsors: true
 
     The classic example program that prints "Hello, world!" to the console.
 
-{% highlight rust %}
+{% highlight gleam %}
 import gleam/io
 
 pub fn main() {
@@ -116,7 +116,7 @@ pub fn main() {
     This little web server responds with the text "Hello, world!" to any
     HTTP request made to it.
 
-{% highlight rust %}
+{% highlight gleam %}
 import gleam/bit_builder
 import gleam/http/elli
 import gleam/http
@@ -146,7 +146,7 @@ pub fn start() {
     Here's "Hello, World!" being printed by a thousand processes
     concurrently.
 
-{% highlight rust %}
+{% highlight gleam %}
 import gleam/io
 import gleam/int
 import gleam/list

--- a/javascript/highlightjs-gleam.js
+++ b/javascript/highlightjs-gleam.js
@@ -22,16 +22,20 @@ hljs.registerLanguage("gleam", function (hljs) {
     className: "number",
     variants: [
       {
-        begin: "\\b0b([01_]+)",
+        // binary
+        begin: "\\b0[bB](?:_?[01]+)+",
       },
       {
-        begin: "\\b0o([0-7_]+)",
+        // octal
+        begin: "\\b0[oO](?:_?[0-7]+)+",
       },
       {
-        begin: "\\b0x([A-Fa-f0-9_]+)",
+        // hex
+        begin: "\\b0[xX](?:_?[0-9a-fA-F]+)+",
       },
       {
-        begin: "\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)",
+        // dec, float
+        begin: "\\b\\d(?:_?\\d+)*(?:\\.(?:\\d(?:_?\\d+)*)*)?",
       },
     ],
     relevance: 0,
@@ -44,7 +48,7 @@ hljs.registerLanguage("gleam", function (hljs) {
       hljs.C_LINE_COMMENT_MODE,
       STRING,
       {
-        // bitstrings
+        // bit string
         begin: "<<",
         end: ">>",
         contains: [
@@ -55,10 +59,11 @@ hljs.registerLanguage("gleam", function (hljs) {
               "utf8_codepoint utf16_codepoint utf32_codepoint signed unsigned " +
               "big little native unit size",
           },
+          KEYWORDS,
           STRING,
-          NUMBER,
           NAME,
           DISCARD_NAME,
+          NUMBER,
         ],
         relevance: 10,
       },
@@ -70,7 +75,7 @@ hljs.registerLanguage("gleam", function (hljs) {
         contains: [
           {
             className: "title",
-            begin: "[a-zA-Z0-9_]\\w*",
+            begin: "[a-z][a-z0-9_]*\\w*",
             relevance: 0,
           },
         ],
@@ -82,24 +87,18 @@ hljs.registerLanguage("gleam", function (hljs) {
       {
         // Type names and constructors
         className: "title",
-        begin: "\\b[A-Z][A-Za-z0-9_]*\\b",
+        begin: "\\b[A-Z][A-Za-z0-9]*\\b",
         relevance: 0,
       },
       {
-        // float operators
         className: "operator",
-        begin: "(\\+\\.|-\\.|\\*\\.|/\\.|<\\.|>\\.)",
-        relevance: 10,
-      },
-      {
-        className: "operator",
-        begin: "(->|\\|>|<<|>>|\\+|-|\\*|/|>=|<=|<|<|%|\\.\\.|\\|=|==|!=)",
+        begin: "[+\\-*/%!=<>&|.]+",
         relevance: 0,
       },
-      NUMBER,
       NAME,
       DISCARD_NAME,
+      NUMBER,
     ],
   };
 });
-hljs.initHighlightingOnLoad();
+hljs.highlightAll();

--- a/writing-gleam/documenting-the-project.md
+++ b/writing-gleam/documenting-the-project.md
@@ -12,7 +12,7 @@ To document modules and functions Gleam supports two special comments, `///`
 which is for documenting types and functions, and `////` which is for
 documenting the module as a whole.
 
-```rust
+```gleam
 //// This module contains some useful functions for working
 //// with numbers.
 ////

--- a/writing-gleam/running-the-project.md
+++ b/writing-gleam/running-the-project.md
@@ -19,7 +19,7 @@ To write a test add a function to a module in the `test`, giving the function
 a name that ends in `_test`. The `gleam/should` module can be used to make
 assertions about the behaviour of our code.
 
-```rust
+```gleam
 import gleam/should
 import my_fantastic_library
 
@@ -77,7 +77,7 @@ Running escriptize creates an executable file:
 
 An example main function signature would look like this:
 
-```rust
+```gleam
 import gleam/list
 
 pub external type CharList


### PR DESCRIPTION
Resolves https://github.com/gleam-lang/gleam/issues/981

Updates all Gleam specific code blocks to use the Gleam specifier while taking care to avoid changing the Rust specific code blocks to Gleam. Uses the same light theme CDN and highlight JS rules as the docs.

This also affects the three code snippets on the main page.

----

### Before
![Screenshot 2021-06-09 at 22-28-48 Gleam v0 15 released – Gleam](https://user-images.githubusercontent.com/3239951/121455240-1c1c3f00-c972-11eb-954e-33125a528966.png)

### After
![image](https://user-images.githubusercontent.com/3239951/121455178-06a71500-c972-11eb-9027-607bccc807d9.png)
