### PR TITLE
Fix language tour code highlighting

### DIFF
--- a/book/javascript/highlightjs-gleam.js
+++ b/book/javascript/highlightjs-gleam.js
@@ -94,4 +94,4 @@ hljs.registerLanguage("gleam", function (hljs) {
     ],
   };
 });
-hljs.highlightAll();
+hljs.initHighlightingOnLoad();


### PR DESCRIPTION
Language tour is using v 10.1.1 of highlightjs which does not support highlightAll function, use initHighlightingOnLoad instead as a quick fix

may want to consider upgrading to the same version and using the cdn solution like in the rest of the docs, if I am not wrong that would mean putting the script tag in every html page?