### PR TITLE
Clearify wildcard

### DIFF
--- a/book-src/tour/case-expressions.md
+++ b/book-src/tour/case-expressions.md
@@ -6,14 +6,14 @@ _pattern matching_.
 
 Here we match on an `Int` and return a specific string for the values 0, 1,
 and 2. The final pattern matches any other value that did not match any of
-the previous patterns.
+the previous patterns. You can name this entry, as you want. 
 
 ```gleam
 case some_number {
   0 -> "Zero"
   1 -> "One"
   2 -> "Two"
-  _ -> "Some other number" // This matches anything
+  n -> "Some other number" // This matches anything
 }
 ```
 


### PR DESCRIPTION
So, if I assume correctly - this comes not out clearly of the text - then is the last entry in a case expression always the wildcard, yes?

So in case I put xyz there, this is the 'matches all' case, correct?

In case that is so, let us mention this specifically, since its unique among all languages, so far as I know at least.

I also find it confusing, that different values, like n, _other, other and _ are used in the examples.

I guess this should suggest, that I can use everything, while it also suggests a certain 'conventional pattern' 

But in that case, its more than one convention, and actually mixing multiple different ones.