### PR TITLE
chore: remove end from elm

### DIFF
--- a/cheatsheets/gleam-for-elm-users.md
+++ b/cheatsheets/gleam-for-elm-users.md
@@ -362,7 +362,6 @@ view =
       z + (t * 5) -- Parenthesis are used to group arithmetic expressions
   in
   y + x
-end
 ```
 
 #### Gleam


### PR DESCRIPTION
The elm language does not scope functions with the `end` keyword