### PR TITLE
Use version v0.18.2 instead of v0.14.4 in the build-from-source docs

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -95,7 +95,7 @@ compiler](https://www.rust-lang.org/tools/install).
 ```sh
 # Download the Gleam source code git repository
 cd /tmp
-git clone https://github.com/gleam-lang/gleam.git --branch v0.14.4
+git clone https://github.com/gleam-lang/gleam.git --branch v0.18.2
 cd gleam
 
 # Build the Gleam compiler. This will take some time!


### PR DESCRIPTION
This could help some avoid confusion some beginners, following the guide and then wondering why `gleam` does not even have the expected subcommands. :slightly_smiling_face: