### PR TITLE
Wait for processes to exit in multi-thread example

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,10 @@ import gleam/otp/process
 
 pub fn main() {
   list.range(0, 1000)
-  |> list.each(start_process)
+  |> list.map(start_process)
+  |> list.map(process.monitor_process)  // monitor process for when it exits
+  |> list.each(process.receive(_, 3))   // wait for the exit signals
+
 }
 
 fn start_process(i) {


### PR DESCRIPTION
The previous version wasn't waiting for the processes to exit, so nothing was getting printed.

I'm still very new to gleam (which is why I was running the examples on the website), but hopefully this change is helpful!
