### PR TITLE
install  webrick in readme for ruby3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Install `github-pages` (requires Ruby)
 
 ```sh
 gem install github-pages
+gem install webrick # For Ruby3.x
 ```
 
 and run `make serve` in root directory.


### PR DESCRIPTION
In ruby3.1, I got this error:
```
$ make serve
jekyll server --watch --safe --port 3000 --drafts
 Auto-regeneration: enabled for '/Users/lucas/Documents/demos/gleam-lang/website'
<internal:/Users/lucas/.rbenv/versions/3.1.1/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- webrick (LoadError)
	from <internal:/Users/lucas/.rbenv/versions/3.1.1/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'

```

For more information, plz see this issue: https://github.com/jekyll/jekyll/issues/8523

The simple way to fix it, just add webrick like this:

```
$ gem add webrick
```