### PR TITLE
Fix typo in Elm guide

### DIFF
--- a/cheatsheets/gleam-for-elm-users.md
+++ b/cheatsheets/gleam-for-elm-users.md
@@ -893,7 +893,7 @@ There are some exceptions to that rule for atoms that are commonly used and have
 
 In general, atoms are not used much in Gleam, and are mostly used for booleans, `Ok` and `Error` result types, and defining custom types.
 
-Custom types in Elm can be used to achieve simmilar things to atoms.
+Custom types in Elm can be used to achieve similar things to atoms.
 
 #### Elm
 


### PR DESCRIPTION
Fairly self explanatory! Probably my fault originally :) 