### PR TITLE
docs: Readd rebar3 section

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -20,6 +20,7 @@ for your editor.
 
 - [Installing Gleam](#installing-gleam)
 - [Installing Erlang](#installing-erlang)
+- [Installing Rebar3](#installing-rebar3)
 - [Editor Plugins](#editor-plugins)
 - [GitPod online Gleam development environment](#gitpod-online-gleam-development-environment)
 
@@ -183,6 +184,14 @@ usage instructions can be found here:
 
 - [https://github.com/asdf-vm/asdf](https://github.com/asdf-vm/asdf)
 - [https://github.com/asdf-vm/asdf-erlang](https://github.com/asdf-vm/asdf-erlang)
+
+## Installing rebar3
+
+Gleam uses rebar3, the standard Erlang build tool for its Erlang dependencies.
+Install rebar3 by following the [official rebar3 installation
+instructions][rebar3-install].
+
+[rebar3-install]: https://rebar3.readme.io/docs/getting-started
 
 ## Editor Plugins
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -187,7 +187,8 @@ usage instructions can be found here:
 
 ## Installing rebar3
 
-Gleam uses rebar3, the standard Erlang build tool for its Erlang dependencies.
+When using Erlang based dependencies (such as their web servers and HTTP clients)
+the rebar3 Erlang build tool may need to be installed.
 Install rebar3 by following the [official rebar3 installation
 instructions][rebar3-install].
 


### PR DESCRIPTION
This was removed a bit a ago, but rebar3 is still used when compiling
native Erlang deps. We should still mention it for completion sake.