### PR TITLE
fix: Sponsors button background

### DIFF
--- a/_layouts/top.html
+++ b/_layouts/top.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Ubuntu+Mono&display=swap"> 
     <link rel="stylesheet" href="/styles/index.css?v=2">
     <link id="syntax-theme" rel="stylesheet" href="//unpkg.com/@highlightjs/cdn-assets@11.0.1/styles/atom-one-light.min.css">
+    <link crossorigin="anonymous" media="all" integrity="sha512-KgQrk5hLBb/TnCqv5/Aj1PnNDcNg1GJwAJmCcofWOvheVekdwdaZjLg5FxNyLJsLSZddZueFFCrFkGbxaBbe8g==" rel="stylesheet" href="https://github.githubassets.com/assets/sponsors-embed-2a042b93984b.css">
     <script src="//unpkg.com/@highlightjs/cdn-assets@11.0.1/highlight.min.js"></script>
     <script src="//unpkg.com/@highlightjs/cdn-assets@11.0.1/languages/elixir.min.js"></script>
     <script src="//unpkg.com/@highlightjs/cdn-assets@11.0.1/languages/elm.min.js"></script>
@@ -38,7 +39,14 @@
       <a class="pagenav-link" href="/community">Community</a>
       <a class="pagenav-link" href="/documentation">Docs</a>
       <a class="pagenav-link" href="https://github.com/gleam-lang">Code</a>
-      <iframe src="https://github.com/sponsors/lpil/button" title="Sponsor Gleam" height="35" width="116" style="border: 0; padding-left: 8px"></iframe>
+      <div class="pagenav-link">
+        <a class="btn btn-block" style="box-shadow: none;" aria-label="Sponsor @lpil" target="_top" href="https://github.com/sponsors/lpil?o=esb">
+          <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-heart icon-sponsor color-fg-sponsors mr-2">
+            <path fill-rule="evenodd" d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.75.75 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5zM8 14.25l-.345.666-.002-.001-.006-.003-.018-.01a7.643 7.643 0 01-.31-.17 22.075 22.075 0 01-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.08 22.08 0 01-3.744 2.584l-.018.01-.006.003h-.002L8 14.25zm0 0l.345.666a.752.752 0 01-.69 0L8 14.25z"></path>
+          </svg>
+          <span>Sponsor</span>
+        </a>
+      </div>
     </nav>
 
 {{ content }}


### PR DESCRIPTION
Sponsors button has a black background, as seen below:
![image](https://user-images.githubusercontent.com/29015545/163045492-9f3216f9-5efc-4d02-991f-3e1590e4905a.png)
This fix removes the use of an `iframe`, taking that logic/element into the main layout. It also imports the GitHub CSS. The button now looks like this:
![image](https://user-images.githubusercontent.com/29015545/163045805-754262c3-ef94-43e3-940f-aad70eae5f83.png)
