### PR TITLE
Update section about negation of `Bool`s

### DIFF
--- a/book-src/tour/bools.md
+++ b/book-src/tour/bools.md
@@ -23,8 +23,13 @@ hand side if they don't have to.
 
 `||` evaluates the right hand side if the left hand side is `False`.
 
-Gleam does not define more bool operators like `!` (negation).
-Instead, those are available as functions in the `gleam/bool` module.
+Gleam supports negation of Bools using either the `!` operator or the
+`bool.negate` function from the `gleam/bool` module.
+
+```gleam
+!True  // => False
+!False // => True
+```
 
 ## Erlang interop
 


### PR DESCRIPTION
Thank you for a great project. I've eagerly been following the development of Gleam for a while. :-)

While reading through the language tour, I noticed that the section about booleans is outdated, as we now have the `!` operator available, and I thought it was worth updating it with a code example.