### PR TITLE
Change gleam to Gleam

### DIFF
--- a/book-src/tour/expression-blocks.md
+++ b/book-src/tour/expression-blocks.md
@@ -1,6 +1,6 @@
 # Expression blocks
 
-Every block in gleam is an expression. All expressions in the block are
+Every block in Gleam is an expression. All expressions in the block are
 executed, and the result of the last expression is returned.
 
 ```gleam


### PR DESCRIPTION
The section about expression blocks contains a minor typo, as gleam should be written Gleam which this pull request fixes.