### PR TITLE
Switch iodata to string_builder

### DIFF
--- a/book-src/tour/functions.md
+++ b/book-src/tour/functions.md
@@ -39,16 +39,16 @@ Gleam provides syntax for passing the result of one function to the arguments of
 The pipe operator allows you to chain function calls without using a plethora of parenthesis. For a simple example, consider the following implementation of `string.reverse` in Gleam:
 
 ```gleam
-iodata.to_string(iodata.reverse(iodata.new(string)))
+string_builder.to_string(string_builder.reverse(string_builder.new(string)))
 ```
 
 This can be expressed more naturally using the pipe operator, eliminating the need to track parenthesis closure.
 
 ```gleam
 string
-|> iodata.new
-|> iodata.reverse
-|> iodata.to_string
+|> string_builder.new
+|> string_builder.reverse
+|> string_builder.to_string
 ```
 
 Each line of this expression applies the function to the result of the previous line. This works easily because each of these functions take only one argument. Syntax is available to substitute specific arguments of functions that take more than one argument; for more, look below in the section "Function capturing".


### PR DESCRIPTION
Per https://github.com/gleam-lang/gleam/discussions/1618#discussioncomment-2708606

I originally made this change through github UI, but I realized that
wouldn't build the changes. I cloned locally and ran `make build`, but
that created changes to many files.

So either my system is not configured for generating the docs correctly
or the docs are intentionally not built up-to-date. Either way, I
figured it best to just push the markdown change.
