### PR TITLE
Fix bug in the sponsor section

### DIFF
--- a/_layouts/top.html
+++ b/_layouts/top.html
@@ -74,7 +74,7 @@
   {% if sponsor.tier == 3 %}
           <li>
             <a href="{{ sponsor.url }}" rel="noopener" target="_blank">
-              <img src="{{ sponsor.avatar }}" class="sponsor-tier-{{ sponsor.tier }} {% unless sponsor.square_avatar %} round"{% endunless %} alt="{{ sponsor.name }}">
+              <img src="{{ sponsor.avatar }}" class="sponsor-tier-{{ sponsor.tier }} {% unless sponsor.square_avatar %} round{% endunless %}" alt="{{ sponsor.name }}">
             </a>
   {% endif %}
   {% endfor %}
@@ -86,7 +86,7 @@
   {% if sponsor.tier < 3 %}
           <li>
             <a href="{{ sponsor.url }}" rel="noopener" target="_blank">
-              <img src="{{ sponsor.avatar }}" class="sponsor-tier-{{ sponsor.tier }} {% unless sponsor.square_avatar %} round"{% endunless %} alt="{{ sponsor.name }}">
+              <img src="{{ sponsor.avatar }}" class="sponsor-tier-{{ sponsor.tier }} {% unless sponsor.square_avatar %} round{% endunless %}" alt="{{ sponsor.name }}">
             </a>
   {% endif %}
   {% endfor %}


### PR DESCRIPTION
The markup is broken when the sponsor has `square_avatar` set to true:
<img width="512" alt="image" src="https://user-images.githubusercontent.com/9519976/198003099-de285063-91f8-4df0-b21e-ae9c1df2d334.png">

This PR fixes this issue by moving the `{% endunless %}` statement to inside the closing quote.