### PR TITLE
Fix for a small grammar error on creating a project

### DIFF
--- a/_posts/2022-10-25-gleam-v0.24-released.md
+++ b/_posts/2022-10-25-gleam-v0.24-released.md
@@ -46,7 +46,7 @@ for his tireless work on Gleam-Elixir interop.
 ## <> operator
 
 Gleam now has a `<>` operator which works on strings. In an expression it
-immutably concatenates two string into a new one.
+immutably concatenates two strings into a new one.
 
 ```gleam
 let who = "Joe"

--- a/writing-gleam/creating-a-project.md
+++ b/writing-gleam/creating-a-project.md
@@ -25,7 +25,7 @@ You'll now have a project with this structure:
 ```
 
 Regular Gleam code goes in the `src` directory, and the tests for this code
-goes in the `test` directory.
+go in the `test` directory.
 
 You can run your project with the `gleam run` command and test it with the
 `gleam test` command.


### PR DESCRIPTION
Found what I think is a small grammar error. If I'm not mistaken, in the subordinate sentence "and the tests for this code goes in the `test` directory", the subject is "the tests", so then the verb should be "go".

The sentence would then be "and the tests for this code go in the `test` directory".