### PR TITLE
Fix broken link to rebar3 installation steps

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -213,7 +213,7 @@ the rebar3 Erlang build tool may need to be installed.
 Install rebar3 by following the [official rebar3 installation
 instructions][rebar3-install].
 
-[rebar3-install]: https://rebar3.readme.io/docs/getting-started
+[rebar3-install]: https://rebar3.org/docs/getting-started/
 
 ## Editor Plugins
 


### PR DESCRIPTION
Hi !

I was trying to install Gleam on my machine to toy a bit with it, and I found that the link to rebar3 installation steps does not exist anymore.

I hope the new link I provided is the correct one !

Cheers :)