### PR TITLE
fix: code comments going out of bounds

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -637,7 +637,11 @@ td {
   color: var(--color-code-blue);
 }
 
-.hljs-comment,
+.hljs-comment {
+  word-break: break-word;
+  color: var(--color-code-grey)
+}
+
 .code-comment {
   color: var(--color-code-grey);
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -637,11 +637,7 @@ td {
   color: var(--color-code-blue);
 }
 
-.hljs-comment {
-  word-break: break-word;
-  color: var(--color-code-grey)
-}
-
+.hljs-comment,
 .code-comment {
   color: var(--color-code-grey);
 }
@@ -659,6 +655,7 @@ td {
 }
 
 .page pre {
+  overflow-y: auto;
   margin: var(--gap-3) 0 var(--gap-4) 0;
   padding: var(--gap-2) var(--gap-2);
   background-color: var(--color-black);


### PR DESCRIPTION
Fixes `gleam.toml` code comments going out of bounds on Mobile displays.

Before: 
![image](https://user-images.githubusercontent.com/62379502/216142774-61598567-80f0-4943-8181-3ccac63983af.png)

After:
![image](https://user-images.githubusercontent.com/62379502/216142925-b2bf962e-b4bb-48a2-bbc6-498068ae3c45.png)
