### PR TITLE
Fix typo

### DIFF
--- a/book/tour/expression-blocks.html
+++ b/book/tour/expression-blocks.html
@@ -153,7 +153,7 @@ executed, and the result of the last expression is returned.</p>
     False
 } // =&gt; False
 </code></pre>
-<p>Expression blocks can be used instead of parenthesis to change the precedence
+<p>Expression blocks can be used instead of parentheses to change the precedence
 of operations.</p>
 <pre><code class="language-gleam">let celsius = { fahrenheit - 32 } * 5 / 9
 </code></pre>


### PR DESCRIPTION
I fixed a misspelling of "parentheses." "Parenthesis" is singular, while "parentheses" is plural, just to clarify why I edited it.