### PR TITLE
Fix typo

### DIFF
--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -14,7 +14,7 @@
       </div>
       <div>
         <a href="/documentation">Documentation</a>
-        <a href="https://github.com/gleam-lang">Github</a>
+        <a href="https://github.com/gleam-lang">GitHub</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
Changed Git**h**ub to Git**H**ub.

This keeps consistency with:
https://github.com/gleam-lang/website/blob/302d8194c3dee82650ab72bad7026b27f4606ade/_layouts/layout.html#L50