### PR TITLE
Provide arg to mist.run_service, required for demo to compile/run.

### DIFF
--- a/deployment/fly.md
+++ b/deployment/fly.md
@@ -33,7 +33,7 @@ import gleam/bit_builder
 import gleam/http/response.{Response}
 
 pub fn main() {
-  assert Ok(_) = mist.run_service(8080, web_service)
+  assert Ok(_) = mist.run_service(8080, web_service, max_body_limit: 4_000_000)
   process.sleep_forever()
 }
 


### PR DESCRIPTION
The current demo doesn't compile without the third argument, this is a modification provides the third argument and allows the demo to compile.