### PR TITLE
Update link to Sublime Text package

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -224,7 +224,7 @@ niceties.
 - **Vim** - [https://github.com/gleam-lang/gleam.vim](https://github.com/gleam-lang/gleam.vim)
 - **Emacs** - [https://github.com/gleam-lang/gleam-mode](https://github.com/gleam-lang/gleam-mode)
 - **Visual Studio Code** - [https://github.com/gleam-lang/vscode-gleam](https://github.com/gleam-lang/vscode-gleam)
-- **Sublime Text 3** - [https://github.com/molnarmark/sublime-gleam](https://github.com/molnarmark/sublime-gleam)
+- **Sublime Text** - [https://github.com/digitalcora/sublime-text-gleam](https://github.com/digitalcora/sublime-text-gleam)
 - **Atom** - [https://github.com/itsgreggreg/language-gleam](https://github.com/itsgreggreg/language-gleam)
 - **Gedit** - [https://github.com/DannyLettuce/gleam_gedit](https://github.com/DannyLettuce/gleam_gedit)
 


### PR DESCRIPTION
For details see: gleam-lang/awesome-gleam#64

Random fact: Specifying "Sublime Text 3" rather than just "Sublime Text" used to be common because version 3 had a very long "technically beta but stable enough that lots of people use it" development phase (4 years!). Things are a bit different now that 4 has been the current stable version for a couple years and 3 appears to be mostly done getting updates (last one in 2019). In fact, my package only supports 4+, though for now it works fine if installed on 3.