### PR TITLE
Fix minor typo in javascript filename.

### DIFF
--- a/book/tour/external-functions.html
+++ b/book/tour/external-functions.html
@@ -172,7 +172,7 @@ pub external fn inspect(a) -&gt; a =
 <h2 id="javascript-external-functions"><a class="header" href="#javascript-external-functions">JavaScript external functions</a></h2>
 <p>When importing a JavaScript function the path to the module is given instead of
 the module name.</p>
-<pre><code class="language-javascript">// In src/my-module.mjs
+<pre><code class="language-javascript">// In src/my-module.js
 export function run() {
   return 0;
 }


### PR DESCRIPTION
The javascript filename presented ends in .mjs, which is probably a typo.   I am new to javascript, so perhaps it is not.  

Thank you for considering this MR.

