### PR TITLE
Replace `assert` with `let assert`

### DIFF
--- a/cheatsheets/gleam-for-elixir-users.md
+++ b/cheatsheets/gleam-for-elixir-users.md
@@ -103,13 +103,13 @@ let size = 1
 
 #### Gleam
 
-In Gleam, `let` and `=` can be used for pattern matching, but you'll get compile errors if there's a type mismatch, and a runtime error if there's a value mismatch. For assertions, the equivalent `assert` keyword is preferred.
+In Gleam, `let` and `=` can be used for pattern matching, but you'll get compile errors if there's a type mismatch, and a runtime error if there's a value mismatch. For assertions, the equivalent `let assert` keyword is preferred.
 
 ```gleam
-assert [x, y] = [1, 2]
-assert 2 = y // assert that y is 2
-assert 2 = x // runtime error
-assert [y] = "Hello" // compile error, type mismatch
+let assert [x, y] = [1, 2]
+let assert 2 = y // assert that y is 2
+let assert 2 = x // runtime error
+let assert [y] = "Hello" // compile error, type mismatch
 ```
 
 ### Variables type annotations

--- a/cheatsheets/gleam-for-erlang-users.md
+++ b/cheatsheets/gleam-for-erlang-users.md
@@ -78,12 +78,12 @@ used to assert that a given term has a specific shape.
 
 #### Gleam
 
-In Gleam the `assert` keyword is used to make assertions using partial
+In Gleam, the `let assert` keyword is used to make assertions using partial
 patterns.
 
 ```gleam
 let [element] = some_list // Compile error! Partial pattern
-assert [element] = some_list
+let assert [element] = some_list
 ```
 
 ### Variables type annotations

--- a/cheatsheets/gleam-for-php-users.md
+++ b/cheatsheets/gleam-for-php-users.md
@@ -164,7 +164,7 @@ variable names.
 
 In Gleam, `let` and `=` can be used for pattern matching, but you'll get
 compile errors if there's a type mismatch, and a runtime error if there's
-a value mismatch. For assertions, the equivalent `assert` keyword is
+a value mismatch. For assertions, the equivalent `let assert` keyword is
 preferred.
 
 ```gleam
@@ -172,8 +172,8 @@ let #(a, _) = #(1, 2)
 // a = 1
 // `_` matches 2 and is discarded
 
-assert [] = [1] // runtime error
-assert [y] = "Hello" // compile error, type mismatch
+let assert [] = [1] // runtime error
+let assert [y] = "Hello" // compile error, type mismatch
 ```
 
 Asserts should be used with caution.

--- a/cheatsheets/gleam-for-python-users.md
+++ b/cheatsheets/gleam-for-python-users.md
@@ -112,12 +112,12 @@ for key, value in enumerate(a_dict):
 
 #### Gleam
 
-In Gleam, `let` and `=` can be used for pattern matching, but you'll get compile errors if there's a type mismatch, and a runtime error if there's a value mismatch. For assertions, the equivalent `assert` keyword is preferred.
+In Gleam, `let` and `=` can be used for pattern matching, but you'll get compile errors if there's a type mismatch, and a runtime error if there's a value mismatch. For assertions, the equivalent `let assert` keyword is preferred.
 
 ```gleam
 let #(x, _) = #(1, 2)
-assert [] = [1] // runtime error
-assert [y] = "Hello" // compile error, type mismatch
+let assert [] = [1] // runtime error
+let assert [y] = "Hello" // compile error, type mismatch
 ```
 
 ### Variables type annotations

--- a/cheatsheets/gleam-for-rust-users.md
+++ b/cheatsheets/gleam-for-rust-users.md
@@ -110,12 +110,12 @@ let [y] = "Hello"; // compile error, type mismatch
 
 #### Gleam
 
-In Gleam, `let` and `=` can also be used for pattern matching, but you'll get compile errors if there's a type mismatch, and a runtime error if there's a value mismatch. For assertions, the equivalent `assert` keyword is preferred.
+In Gleam, `let` and `=` can also be used for pattern matching, but you'll get compile errors if there's a type mismatch, and a runtime error if there's a value mismatch. For assertions, the equivalent `let assert` keyword is preferred.
 
 ```gleam
 let [x] = [1]
-assert 2 = x // runtime error
-assert [y] = "Hello" // compile error, type mismatch
+let assert 2 = x // runtime error
+let assert [y] = "Hello" // compile error, type mismatch
 ```
 
 ### Variables type annotations


### PR DESCRIPTION
I was reading through the docs, and realized that the "Gleam for <x> users" pages still used `assert` instead of `let assert`. This PR fixes that.