### PR TITLE
Use Gleam package from nixpkgs.

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -52,11 +52,8 @@ sudo port install gleam
 
 ### Using the Nix package manager
 
-There is a [gleam-nix](https://github.com/vic/gleam-nix) flake you can use to get
-any version of Gleam.
-
 ```sh
-nix shell github:vic/gleam-nix --override-input gleam github:gleam-lang/gleam/main -c gleam --help
+nix profile install gleam
 ```
 
 


### PR DESCRIPTION
Now that NixOS/nixpkgs repository contains a community supported [derivation ](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/gleam/default.nix) for Gleam, it is better to point users to use that package instead of using vic's gleam-nix flake.