### PR TITLE
Make external-types.md compile with gleam 0.3

### DIFF
--- a/book-src/tour/external-types.md
+++ b/book-src/tour/external-types.md
@@ -12,12 +12,12 @@ is an example of importing a `Queue` data type and some functions from Erlang's
 ```gleam
 pub type Queue(a)
 
-@external(erlang, "queue" "new")
+@external(erlang, "queue", "new")
 pub fn new() -> Queue(a)
 
-@external(erlang, "queue" "len")
-pub fn length(Queue(a)) -> Int
+@external(erlang, "queue",  "len")
+pub fn length(queue: Queue(a)) -> Int
 
-@external(erlang, "queue" "in")
-pub fn push(Queue(a), a) -> Queue(a)
+@external(erlang, "queue", "in")
+pub fn push(new: a, queue: Queue(a)) -> Queue(a)
 ```

--- a/book/tour/external-types.html
+++ b/book/tour/external-types.html
@@ -155,14 +155,14 @@ is an example of importing a <code>Queue</code> data type and some functions fro
 <code>queue</code> module to work with the new <code>Queue</code> type.</p>
 <pre><code class="language-gleam">pub type Queue(a)
 
-@external(erlang, &quot;queue&quot; &quot;new&quot;)
+@external(erlang, &quot;queue&quot;, &quot;new&quot;)
 pub fn new() -&gt; Queue(a)
 
-@external(erlang, &quot;queue&quot; &quot;len&quot;)
-pub fn length(Queue(a)) -&gt; Int
+@external(erlang, &quot;queue&quot;,  &quot;len&quot;)
+pub fn length(queue: Queue(a)) -&gt; Int
 
-@external(erlang, &quot;queue&quot; &quot;in&quot;)
-pub fn push(Queue(a), a) -&gt; Queue(a)
+@external(erlang, &quot;queue&quot;, &quot;in&quot;)
+pub fn push(new: a, queue: Queue(a)) -&gt; Queue(a)
 </code></pre>
 
                     </main>


### PR DESCRIPTION
I looked at the order of `push` and noticed it was wrong. Then, I wanted to play with the example and it didn't compile. This should compile and work now. Unsure if any other changes need to be made.

```
chiroptical@Barrys-MacBook-Air ~/p/g/test (main)> cat src/test.gleam
import gleam/io

pub type Queue(a)

@external(erlang, "queue", "new")
pub fn new() -> Queue(a)

@external(erlang, "queue", "len")
pub fn length(queue: Queue(a)) -> Int

@external(erlang, "queue", "in")
pub fn push(elem: a, queue: Queue(a)) -> Queue(a)


pub fn main() {
  let queue = new()
  io.debug(length(queue))
  let new_queue = push(0, queue)
  io.debug(length(new_queue))
}
chiroptical@Barrys-MacBook-Air ~/p/g/test (main)> gleam --version
gleam 0.30.0
chiroptical@Barrys-MacBook-Air ~/p/g/test (main)> gleam run
  Compiling gleam_stdlib
  Compiling gleeunit
  Compiling test
   Compiled in 0.01s
    Running test.main
0
1
```