### PR TITLE
Larger font and list spacing

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -55,7 +55,7 @@
   /* TODO: condense these into a few appopriatedly named variables */
   --font-size-small: 12px;
   --font-size-code: 16px;
-  --font-size-normal: 18px;
+  --font-size-normal: 22px;
   --font-size-navbar: 18px;
   --font-size-hero-button: 24px;
   --font-size-pair-text: 22px;
@@ -93,7 +93,7 @@
   --sponsors-max-height: calc(
     var(--sponsors-row-height) * var(--sponsors-max-row-count)
   );
-  --sponsors-expand-transition: all 2.0s ease;
+  --sponsors-expand-transition: all 2s ease;
 }
 
 * {
@@ -165,6 +165,10 @@ td {
   width: var(--width-content);
   margin: 0 auto;
   padding: var(--gap-2);
+}
+
+.content li {
+  margin-bottom: var(--gap-1);
 }
 
 .navbar {


### PR DESCRIPTION
Following this post by @lpil: https://twitter.com/louispilfold/status/1704624186830807255
I visited other pages and the biggest difference from the homepage was the smaller font (18px vs 22px on the homepage) and lists feeling a bit "squished"

This keep font size consistent between homepage and other pages at 22px and adds a little bit of margin under each list element 

# Before
<img width="1256" alt="Screenshot 2023-09-20 at 21 36 49" src="https://github.com/gleam-lang/website/assets/8095395/a6d07cf8-e7fb-44aa-8805-5f0cea0c66d5">

# After 
<img width="1255" alt="Screenshot 2023-09-20 at 21 36 32" src="https://github.com/gleam-lang/website/assets/8095395/97b69881-3c33-4346-9c3f-5748bfefa96e">
