### PR TITLE
fix look of the unknown field error in the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@ content=header_content %}
   ┌─ ./src/app.gleam:8:16
   │
 8 │ user.alias
-  │ <span class="code-error">^^^^^^^^^^ Did you mean `name`?</span>
+  │ <span class="code-error">    ^^^^^^ Did you mean `name`?</span>
 
 The value being accessed has this type:
     User


### PR DESCRIPTION
When [this PR](https://github.com/gleam-lang/gleam/pull/2375) gets merged and released in a new version of the language, this will fix the look of the error in Gleam's homepage to make it consistent with the new compiler's behaviour