### PR TITLE
Update book, expression blocks as parentheses

### DIFF
--- a/book-src/tour/expression-blocks.md
+++ b/book-src/tour/expression-blocks.md
@@ -11,7 +11,7 @@ let value: Bool = {
 } // => False
 ```
 
-Expression blocks can be used instead of parentheses to change the precedence
+Expression blocks are used instead of parentheses to change the precedence
 of operations.
 
 ```gleam


### PR DESCRIPTION
The phrase "can be used instead of parentheses" is ambiguous. It makes it seem like you can use parentheses or expression blocks, when in fact you can only use expression blocks. 