### PR TITLE
Update fly deployment guide, use v0.32.2 image

### DIFF
--- a/deployment/fly.md
+++ b/deployment/fly.md
@@ -55,7 +55,7 @@ for deployment.
 Add a file named `Dockerfile` with these contents:
 
 ```dockerfile
-FROM ghcr.io/gleam-lang/gleam:v0.22.0-erlang-alpine
+FROM ghcr.io/gleam-lang/gleam:v0.32.2-erlang-alpine
 
 # Add project code
 COPY . /build/


### PR DESCRIPTION
The deployment guide uses an older version of Gleam. 

## Changes
- Update fly deployment guide docker image