### PR TITLE
fix writing-gleam.md `vars/internal`

### DIFF
--- a/writing-gleam.md
+++ b/writing-gleam.md
@@ -240,7 +240,7 @@ fn get(name: String) -> Nil {
 ```
 ```gleam
 // in src/vars/internal.gleam
-fn format_pair(name: String, value: String) -> String {
+pub fn format_pair(name: String, value: String) -> String {
   name <> "=" <> value
 }
 ```


### PR DESCRIPTION
Following through the docs and seems this is a mistake? Cheers!