### PR TITLE
fix: deployment documentation example application

### DIFF
--- a/deployment/fly.md
+++ b/deployment/fly.md
@@ -29,7 +29,7 @@ defines a micro web application.
 ```gleam
 import mist
 import gleam/erlang/process
-import gleam/byte_builder
+import gleam/bytes_builder
 import gleam/http/response.{Response}
 
 pub fn main() {
@@ -42,7 +42,7 @@ pub fn main() {
 }
 
 fn web_service(_request) {
-  let body = byte_builder.from_string("Hello, Joe!")
+  let body = bytes_builder.from_string("Hello, Joe!")
   Response(200, [], mist.Bytes(body))
 }
 ```


### PR DESCRIPTION
The `src/my_web_app.gleam` code is not working, I'm getting this error at run/build:

```
error: Unknown module
...
 │ import gleam/byte_builder
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^
```

I replaced `byte_builder` by `bytes_builder` in the script and it was ok