### PR TITLE
Fix typo of 'approximately' on Gleam 1.0 release post

### DIFF
--- a/_posts/2024-03-04-gleam-version-1.md
+++ b/_posts/2024-03-04-gleam-version-1.md
@@ -156,7 +156,7 @@ The last part of sustainability is financial.
 
 I am able to afford to work on Gleam full time thanks to the support of the
 project's sponsors on [GitHub Sponsors][sponsors]. The largest contributor is
-[Fly.io](https://fly.io), who provide approixmately half the funding. Thank you
+[Fly.io](https://fly.io), who provide approximately half the funding. Thank you
 Fly.io! We wouldn't be here today without your support!
 
 [sponsors]: https://github.com/sponsors/lpil


### PR DESCRIPTION
Small typo I noticed while reading the announcement. Congrats for v1! 🎉 