### PR TITLE
docs: add deployment guide link to Clever Cloud

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -29,6 +29,7 @@ layout: page
 
 ## Deployment
 
+- [Deploying on Cleveer Cloud](https://github.com/davlgd/gleam-demo)
 - [Deploying on Fly.io](/deployment/fly)
 
 ## About Gleam


### PR DESCRIPTION
As I've published a deployment guide for Gleam on Clever Cloud, I've added the link to official documentation. If you prefer I can provide it as a dedicated Markdown page based on existing guide. 