### PR TITLE
Fix missing images on the branding website

### DIFF
--- a/branding.html
+++ b/branding.html
@@ -108,6 +108,6 @@ layout: page
   }
 
   .lucys img {
-    max-height: 165px;
+    height: 165px;
   }
 </style>


### PR DESCRIPTION
After replacing dimensions with `viewBox` attributes in https://github.com/gleam-lang/website/pull/316 the images disappeared as they didn't have an explicit size