### PR TITLE
Fix small error in PHPs arrowFunction Syntax

### DIFF
--- a/cheatsheets/gleam-for-php-users.md
+++ b/cheatsheets/gleam-for-php-users.md
@@ -254,7 +254,7 @@ bound to variables.
 $x = 2
 $phpAnonFn = function($y) use ($x) { return $x * $y; }; // Creates a new scope
 $phpAnonFn(2, 3); // 6
-$phpArrowFn = ($x) => $x * $y; // Inherits the outer scope
+$phpArrowFn = fn ($x) => $x * $y; // Inherits the outer scope
 $phpArrowFn(2, 3); // 6
 ```
 


### PR DESCRIPTION
Arrow functions in PHP are written like: 
```php
$arrow = fn () =>  'Something';
```
the `fn` was missing in the docs.