### PR TITLE
Mac OS X -> macOS in the Installing page

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -31,7 +31,7 @@ The easiest way to install Gleam on Linux, Windows, and Apple macOS is to downlo
 prebuilt version of the compiler from the [GitHub release
 page](https://github.com/gleam-lang/gleam/releases).
 
-### Mac OS X
+### macOS
 
 #### Using Homebrew
 
@@ -176,7 +176,7 @@ sudo apt-get install esl-erlang
 ```
 
 
-#### Mac OS X
+#### macOS
 
 ##### Using Homebrew
 


### PR DESCRIPTION
Easy one!

Apple renamed Mac OS X to macOS in June 2016, see [this post](https://512pixels.net/2016/06/history-of-macos/) for example.