### PR TITLE
Update installation instructions for Arch Linux (use AUR helper)

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -69,6 +69,9 @@ asdf.
 Gleam is available through the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository)
 as package `gleam`. You can use your prefered [helper](https://wiki.archlinux.org/index.php/AUR_helpers)
 to install it or clone it for manual build from [https://aur.archlinux.org/packages/gleam-git](https://aur.archlinux.org/packages/gleam-git).
+```sh
+paru -S gleam
+```
 
 ### FreeBSD
 


### PR DESCRIPTION
This Pull Request updates the installation instructions for Arch Linux:

- Clarifies that an AUR helper like `paru` is needed for installation.
- Provides an example command using `paru` to install the `gleam` package.
- Maintains the link to the AUR package for manual build.

Before:
```
### Arch Linux

Gleam is available through the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository)
as package `gleam`. You can use your prefered [helper](https://wiki.archlinux.org/index.php/AUR_helpers)
to install it or clone it for manual build from [https://aur.archlinux.org/packages/gleam-git](https://aur.archlinux.org/packages/gleam-git).
```
![gleam run_getting-started_installing_ (1)](https://github.com/gleam-lang/website/assets/157634505/04bcefbf-6aeb-44fa-bf93-4c2915b83b8c)

After: 
### Arch Linux

```
Gleam is available through the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository)
as package `gleam`. You can use your prefered [helper](https://wiki.archlinux.org/index.php/AUR_helpers)
to install it or clone it for manual build from [https://aur.archlinux.org/packages/gleam-git](https://aur.archlinux.org/packages/gleam-git).
```sh
paru -S gleam
```
![localhost_3000_getting-started_installing_](https://github.com/gleam-lang/website/assets/157634505/be274af6-1719-4bbb-8be3-6629a2eff251)

Additional Notes:
paru is an example of an AUR helper and other options exist.
Consider including a link to the documentation for AUR helpers.
[https://wiki.archlinux.org/title/AUR_helpers](Arch Wiki about AUR Helpers)