### PR TITLE
Update gleam-for-php-users.md

### DIFF
--- a/cheatsheets/gleam-for-php-users.md
+++ b/cheatsheets/gleam-for-php-users.md
@@ -287,11 +287,11 @@ is that module functions heads may also feature argument labels, like so:
 
 ```gleam
 // In some module.gleam
-pub fn absolute_distance(from x: Int, to y: Int) -> Int {
-  abs(x) - abs(y) |> abs()
+pub fn distance(from x: Int, to y: Int) -> Int {
+  x - y |> int.absolute_value()
 }
 // In some other function
-absolute_distance(from: 1, to: -2) // 1
+distance(from: 1, to: -2) // 3
 ```
 
 ### Exporting functions

--- a/cheatsheets/gleam-for-php-users.md
+++ b/cheatsheets/gleam-for-php-users.md
@@ -287,11 +287,11 @@ is that module functions heads may also feature argument labels, like so:
 
 ```gleam
 // In some module.gleam
-pub fn distance(from x: Int, to y: Int) : Int {
+pub fn absolute_distance(from x: Int, to y: Int) -> Int {
   abs(x) - abs(y) |> abs()
 }
 // In some other function
-distance(from: 1, to: -2) // 1
+absolute_distance(from: 1, to: -2) // 1
 ```
 
 ### Exporting functions


### PR DESCRIPTION
fix typo about return type, also rename function,

this works:

```gleam
import gleam/int
import gleam/io

pub fn absolute_distance(from x: Int, to y: Int) -> Int {
  int.absolute_value(x) - int.absolute_value(y) |> int.absolute_value()
}

pub fn main() {
// In some other function
  let dist = absolute_distance(from: 1, to: -2) // 1
  io.debug(dist)
}
```