### PR TITLE
Update docker image tag on the `fly.md` page to `v1.0.0` 

### DIFF
--- a/deployment/fly.md
+++ b/deployment/fly.md
@@ -59,7 +59,7 @@ for deployment.
 Add a file named `Dockerfile` with these contents:
 
 ```dockerfile
-FROM ghcr.io/gleam-lang/gleam:v0.34.1-erlang-alpine
+FROM ghcr.io/gleam-lang/gleam:v1.0.0-erlang-alpine
 
 # Add project code
 COPY . /build/


### PR DESCRIPTION
## Issue

The deployement example on the website uses an older tag for the docker image. This resulted in some dependency issues for packages that required a minimum of version `v1.0`.

`Glint` was the package I experienced this issue on with the following error

```
The package `glint` requires a Gleam version satisfying ~> 1.0 but you are using v0.34.1.
```

## Replicate

- Create a new gleam project
- Add the `glint` package
- Copy the `dockerfile` from the website
- run `docker run`

## Fix

Updated the dockerfile snippet to use the `v1.0.0` tag instead of the `v0.34.1` tag