### PR TITLE
chore: update installation instructions to mention homebrew for linux

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -50,21 +50,31 @@ With [MacPorts](https://www.macports.org/) installed run the following:
 sudo port install gleam
 ```
 
-### Using the Nix package manager
+### Linux
+
+#### Using Homebrew
+
+With [Homebrew](https://brew.sh) installed run the following:
+
+```sh
+brew update
+brew install gleam
+```
+
+#### Using the Nix package manager
 
 ```sh
 nix profile install gleam
 ```
 
-
-### asdf version manager
+#### asdf version manager
 
 [asdf](https://github.com/asdf-vm/asdf) is a tool for installing and managing
 multiple version of programming languages at the same time. Install the
 [asdf-gleam plugin](https://github.com/vic/asdf-gleam) to manage Gleam with
 asdf.
 
-### Alpine Linux
+#### Alpine Linux
 
 Gleam is available in the Community repository of Alpine Linux as a package `gleam`. Install it with:
 
@@ -72,13 +82,13 @@ Gleam is available in the Community repository of Alpine Linux as a package `gle
 apk add gleam
 ```
 
-### Arch Linux
+#### Arch Linux
 
 Gleam is available through the [Arch User Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository)
 as package `gleam`. You can use your prefered [helper](https://wiki.archlinux.org/index.php/AUR_helpers)
 to install it or clone it for manual build from [https://aur.archlinux.org/packages/gleam-git](https://aur.archlinux.org/packages/gleam-git).
 
-### FreeBSD
+#### FreeBSD
 
 Gleam is available in ports, and also in binary packages. You may need
 to use the `latest` package repo, amend per instructions in
@@ -90,7 +100,7 @@ $ pkg install -r FreeBSD lang/gleam lang/erlang-runtime23
 $ export PATH=/usr/local/lib/erlang23/bin:$PATH
 ```
 
-### OpenBSD
+#### OpenBSD
 
 For OpenBSD -current, Gleam is available as a binary package. You can install it with:
 
@@ -98,7 +108,7 @@ For OpenBSD -current, Gleam is available as a binary package. You can install it
 $ doas pkg_add gleam
 ```
 
-### Void Linux
+#### Void Linux
 
 Gleam is available as part of the official packages repository. Install it with:
 
@@ -140,7 +150,8 @@ gleam --version
 ## Installing Erlang
 
 Gleam compiles to Erlang code, so Erlang needs to be installed to run Gleam
-code.
+code. Some of the above package managers (e.g. Homebrew) will install Erlang
+alongside Gleam automatically.
 
 Precompiled builds for many popular operating systems can be downloaded from
 the [Erlang solutions website](https://www.erlang-solutions.com/resources/download.html).
@@ -154,7 +165,17 @@ erl -version
 Erlang (SMP,ASYNC_THREADS) (BEAM) emulator version 12.1.5
 ```
 
-#### Linux
+### Linux
+
+#### Using Homebrew
+
+[Homebrew](https://brew.sh) will install Erlang alongside Gleam automatically,
+though it can be manually installed by running the following:
+
+```sh
+brew update
+brew install erlang
+```
 
 #### Alpine Linux (Community repository)
 
@@ -174,7 +195,7 @@ pacman -S erlang
 dnf install elixir erlang
 ```
 
-##### Debian, Ubuntu, Raspberry Pi OS
+#### Debian, Ubuntu, Raspberry Pi OS
 
 ```shell
 wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb
@@ -183,12 +204,12 @@ sudo apt-get update
 sudo apt-get install esl-erlang
 ```
 
+### macOS
 
-#### macOS
+#### Using Homebrew
 
-##### Using Homebrew
-
-With [Homebrew](https://brew.sh) installed run the following:
+[Homebrew](https://brew.sh) will install Erlang alongside Gleam automatically,
+though it can be manually installed by running the following:
 
 ```sh
 brew update
@@ -203,9 +224,9 @@ With [MacPorts](https://www.macports.org/) installed run the following:
 sudo port install erlang
 ```
 
-#### Windows
+### Windows
 
-##### Using Chocolatey
+#### Using Chocolatey
 
 With [Chocolatey](https://chocolatey.org/) installed on your computer run the
 following:
@@ -214,7 +235,7 @@ following:
 choco install erlang
 ```
 
-##### Using Scoop
+#### Using Scoop
 
 With [Scoop](https://scoop.sh/) installed on your computer run the following:
 
@@ -222,9 +243,9 @@ With [Scoop](https://scoop.sh/) installed on your computer run the following:
 scoop install erlang
 ```
 
-#### Using version managers
+### Using version managers
 
-##### asdf
+#### asdf
 
 The asdf version manager has a plugin for installing Erlang. Installation and
 usage instructions can be found here:


### PR DESCRIPTION
Move Homebrew into a new 'cross-platform' section with `asdf`, and fix up some headers