### PR TITLE
feat: add link to installation instructions on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,10 @@ preload:
   <b>Gleam</b> is a <b>friendly</b> language for building
   <b>type-safe</b> systems that <b>scale</b>!
 </div>
-<a class="button" href="https://tour.gleam.run/">Try Gleam</a>
+<div class="hero-links">
+  <a class="button" href="https://tour.gleam.run/">Try Gleam</a>
+  <a class="hero-link" href="/getting-started/installing">Install Gleam</a>
+</div>
 {% endcapture %} {% include page-header.html image="/images/lucy/lucy.svg"
 alt="Lucy the star, Gleam's mascot" content=header_content %}
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -294,6 +294,18 @@ main.content {
   margin-top: var(--gap-2);
 }
 
+.hero-links {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--gap-2);
+}
+
+.hero-link {
+  color: var(--color-unexpected-aubergine) !important;
+}
+
 .home-pair {
   padding-top: var(--gap-4);
   padding-bottom: var(--gap-4);


### PR DESCRIPTION
Adds a link to installation instructions in the homepage hero. Previously it was difficult to find installation instructions.

<img width="473" alt="Screenshot 2024-03-22 at 08 36 23" src="https://github.com/gleam-lang/website/assets/47423046/3749b8bf-81d1-40ca-8d22-7c69a89b1681">
