### PR TITLE
Add temporary openSUSE installation instructions

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -119,6 +119,16 @@ For OpenBSD -current, Gleam is available as a binary package. You can install it
 $ doas pkg_add gleam
 ```
 
+### openSUSE
+
+For openSUSE the package is in the process of being accepted into the official repository.
+For now you will have to add the package's repository yourself and then install from it:
+```
+# zypper addrepo -f https://download.opensuse.org/repositories/home:/Pi-Cla/openSUSE_Tumbleweed/ gleam_repo
+# zypper refresh
+# zypper install gleam
+```
+
 ### Windows
 
 #### Using Scoop


### PR DESCRIPTION
These will be replaced with just
```
# zypper install gleam
```
once Gleam is accepted into the official repository. I don't know why it is taking so long though, openSUSE is usually good with accepting new packages quickly....