### PR TITLE
Rename mentions of the old Map type to Dict

### DIFF
--- a/cheatsheets/gleam-for-elixir-users.md
+++ b/cheatsheets/gleam-for-elixir-users.md
@@ -25,7 +25,7 @@ subtitle: Hello Elixir Alchemists!
   - [Tuples](#tuples)
   - [Lists](#lists)
   - [Atoms](#atoms)
-  - [Maps](#maps)
+  - [Dicts](#dicts)
 - [Patterns] TODO
 - [Flow control](#flow-control) TODO
   - [Case](#case) TODO
@@ -556,11 +556,11 @@ Ok(True)
 Error(False)
 ```
 
-### Maps
+### Dicts
 
-In Elixir, maps can have keys and values of any type, and they can be mixed in a given map. In Gleam, maps can have keys and values of any type, but all keys must be of the same type in a given map and all values must be of the same type in a given map.
+In Elixir, maps can have keys and values of any type, and they can be mixed in a given map. In Gleam, maps are called Dict (Dictionary) and provided by the standard library. Dicts can have keys and values of any type, but all keys must be of the same type in a given dict and all values must be of the same type in a given dict.
 
-There is no map literal syntax in Gleam, and you cannot pattern match on a map. Maps are generally not used much in Gleam, custom types are more common.
+There is no dictionary literal syntax in Gleam, and you cannot pattern match on a dict. Dicts are generally not used much in Gleam, custom types are more common.
 
 #### Elixir
 
@@ -572,10 +572,10 @@ There is no map literal syntax in Gleam, and you cannot pattern match on a map. 
 #### Gleam
 
 ```gleam
-import gleam/map
+import gleam/dict
 
-map.from_list([#("key1", "value1"), #("key2", "value2")])
-map.from_list([#("key1", "value1"), #("key2", 2)]) // Type error!
+dict.from_list([#("key1", "value1"), #("key2", "value2")])
+dict.from_list([#("key1", "value1"), #("key2", 2)]) // Type error!
 ```
 
 ## Custom types

--- a/cheatsheets/gleam-for-elm-users.md
+++ b/cheatsheets/gleam-for-elm-users.md
@@ -558,11 +558,11 @@ The standard library provides the [gleam/list](https://hexdocs.pm/gleam_stdlib/g
 
 ### Dicts
 
-Dict in Elm and Map in Gleam have similar properties and purpose.
+Dict in Elm and Dict in Gleam have similar properties and purpose.
 
-In Gleam, maps can have keys and values of any type, but all keys must be of the same type in a given map and all values must be of the same type in a given map.
+In Gleam, dicts can have keys and values of any type, but all keys must be of the same type in a given dict and all values must be of the same type in a given dict.
 
-Like Elm, there is no map literal syntax in Gleam, and you cannot pattern match on a map.
+Like Elm, there is no dict literal syntax in Gleam, and you cannot pattern match on a dict.
 
 #### Elm
 
@@ -576,10 +576,10 @@ Dict.fromList [ ("key1", "value1"), ("key2", 2) ] -- Compile error
 #### Gleam
 
 ```gleam
-import gleam/map
+import gleam/dict
 
-map.from_list([#("key1", "value1"), #("key2", "value2")])
-map.from_list([#("key1", "value1"), #("key2", 2)]) // Type error!
+dict.from_list([#("key1", "value1"), #("key2", "value2")])
+dict.from_list([#("key1", "value1"), #("key2", 2)]) // Type error!
 ```
 
 ## Operators

--- a/cheatsheets/gleam-for-erlang-users.md
+++ b/cheatsheets/gleam-for-erlang-users.md
@@ -25,7 +25,7 @@ subtitle: Hello Erlangers and their many 9s!
   - [Tuples](#tuples)
   - [Lists](#lists)
   - [Atoms](#atoms)
-  - [Maps](#maps)
+  - [Dicts](#dicts)
 - [Patterns](#patterns) TODO
 - [Flow control](#flow-control) TODO
   - [Case](#case) TODO
@@ -538,13 +538,11 @@ Ok(True)
 Error(False)
 ```
 
-### Maps
+### Dicts
 
-In Erlang, maps can have keys and values of any type, and they can be mixed in a given map. In
-Gleam, maps can have keys and values of any type, but all keys must be of the same type in a given
-map and all values must be of the same type in a given map.
+In Erlang, maps can have keys and values of any type, and they can be mixed in a given map. In Gleam, maps are called Dict (Dictionary) and provided by the standard library. Dicts can have keys and values of any type, but all keys must be of the same type in a given dict and all values must be of the same type in a given dict.
 
-There is no map literal syntax in Gleam, and you cannot pattern match on a map. Maps are generally
+There is no dict literal syntax in Gleam, and you cannot pattern match on a dict. Dicts are generally
 not used much in Gleam, custom types are more common.
 
 #### Erlang
@@ -557,11 +555,11 @@ not used much in Gleam, custom types are more common.
 #### Gleam
 
 ```gleam
-import gleam/map
+import gleam/dict
 
 
-map.from_list([#("key1", "value1"), #("key2", "value2")])
-map.from_list([#("key1", "value1"), #("key2", 2)]) // Type error!
+dict.from_list([#("key1", "value1"), #("key2", "value2")])
+dict.from_list([#("key1", "value1"), #("key2", 2)]) // Type error!
 ```
 
 

--- a/cheatsheets/gleam-for-php-users.md
+++ b/cheatsheets/gleam-for-php-users.md
@@ -20,7 +20,7 @@ subtitle: Hello Hypertext crafters!
   - [Strings](#strings)
   - [Tuples](#tuples)
   - [Lists](#lists)
-  - [Maps](#maps)
+  - [Dicts](#dicts)
   - [Numbers](#numbers)
 - [Flow control](#flow-control)
   - [Case](#case)
@@ -197,8 +197,8 @@ class Foo {
 }
 ```
 
-As PHP's `array` structure is a combination of maps and arrays.
-The PHP manual states that it is an *ordered map*.
+PHP's `array` structure is an *ordered map*, as stated in the PHP manual,
+and it can be treated as an array, dictionary, etc.
 While creating arrays in PHP the type of its elements cannot be set explicitly
 and each element can be of a different type:
 
@@ -700,9 +700,9 @@ let [1, second_element, ..] = list
 [1.0, ..list] // compile error, type mismatch
 ```
 
-### Maps
+### Dicts
 
-In PHP, the `array` type also covers maps and can have keys of any type as long as:
+In PHP, the `array` type can also be treated as a dictionary and can have keys of any type as long as:
 
 - the key type is `null`, an `int`, a `string` or a `bool` (some conversions
   occur, such as null to `""` and `false` to `0` as well as `true` to `1`
@@ -711,12 +711,12 @@ In PHP, the `array` type also covers maps and can have keys of any type as long 
 - the key is unique in the dictionary.
 - the values are of any type.
 
-In Gleam, maps can have keys and values of any type, but all keys must be of
-the same type in a given map and all values must be of the same type in a
-given map. The type of key and value can differ from each other.
+In Gleam, dicts can have keys and values of any type, but all keys must be of
+the same type in a given dict and all values must be of the same type in a
+given dict. The type of key and value can differ from each other.
 
-There is no map literal syntax in Gleam, and you cannot pattern match on a map.
-Maps are generally not used much in Gleam, custom types are more common.
+There is no dict literal syntax in Gleam, and you cannot pattern match on a dict.
+Dicts are generally not used much in Gleam, custom types are more common.
 
 #### PHP
 
@@ -728,10 +728,10 @@ Maps are generally not used much in Gleam, custom types are more common.
 #### Gleam
 
 ```gleam
-import gleam/map
+import gleam/dict
 
-map.from_list([#("key1", "value1"), #("key2", "value2")])
-map.from_list([#("key1", "value1"), #("key2", 2)]) // Type error!
+dict.from_list([#("key1", "value1"), #("key2", "value2")])
+dict.from_list([#("key1", "value1"), #("key2", 2)]) // Type error!
 ```
 
 ### Numbers

--- a/cheatsheets/gleam-for-python-users.md
+++ b/cheatsheets/gleam-for-python-users.md
@@ -20,7 +20,7 @@ subtitle: Hello productive pragmatic Pythonistas!
   - [Strings](#strings)
   - [Tuples](#tuples)
   - [Lists](#lists)
-  - [Maps](#maps)
+  - [Dicts](#dictionaries)
 - [Flow control](#flow-control)
   - [Case](#case)
   - [Try](#try)
@@ -464,15 +464,15 @@ let [1, second_element, ..] = list
 
 ### Dictionaries
 
-In Python, maps are called dictionaries and can have keys of any type as long as:
+In Python, dictionaries can have keys of any type as long as:
 
 - the key type is `hashable`, such as integers, strings, tuples (due to their immutable values), functions... and custom mutable objects implementing the `__hash__` method.
 - the key is unique in the dictionary.
   and values of any type.
 
-In Gleam, maps can have keys and values of any type, but all keys must be of the same type in a given map and all values must be of the same type in a given map.
+In Gleam, dicts can have keys and values of any type, but all keys must be of the same type in a given dict and all values must be of the same type in a given dict.
 
-There is no map literal syntax in Gleam, and you cannot pattern match on a map. Maps are generally not used much in Gleam, custom types are more common.
+There is no dict literal syntax in Gleam, and you cannot pattern match on a dict. Dicts are generally not used much in Gleam, custom types are more common.
 
 #### Python
 


### PR DESCRIPTION
As in title, many language tours still hadn't been updated to refer to the type as Dict.

This PR just renames and slightly rephrased those sections.