### PR TITLE
Update gleam-for-elm-users.md

### DIFF
--- a/cheatsheets/gleam-for-elm-users.md
+++ b/cheatsheets/gleam-for-elm-users.md
@@ -395,7 +395,7 @@ Elm has a built-in `number` concept that allows it to treat `Int` and `Float` ge
 
 #### Gleam
 
-Operators in Gleam as not generic over `Int` and `Float` so there are separate symbols for `Int` and `Float` operations. For example, `+` adds integers together whilst `+.` adds floats together. The pattern of the additional `.` extends to the other common operators.
+Operators in Gleam are not generic over `Int` and `Float` so there are separate symbols for `Int` and `Float` operations. For example, `+` adds integers together whilst `+.` adds floats together. The pattern of the additional `.` extends to the other common operators.
 
 Additionally, underscores can be added to both integers and floats for clarity.
 

--- a/cheatsheets/gleam-for-elm-users.md
+++ b/cheatsheets/gleam-for-elm-users.md
@@ -307,7 +307,7 @@ pub fn identity(x) {
 
 ```gleam
 // in file main.gleam
-import one // if foo was in a folder called `lib` the import would be `lib/one`
+import one // if `one` was in a folder called `lib` the import would be `lib/one`
 
 pub fn main() {
   one.identity(1)


### PR DESCRIPTION
Fixed a `foo` present where it should be the actual name of the module used in the example (`one`)