### PR TITLE
Add clarification about using Mason in Neovim

### DIFF
--- a/language-server.md
+++ b/language-server.md
@@ -60,6 +60,13 @@ If you are using [`nvim-treesitter`](https://github.com/nvim-treesitter/nvim-tre
 you can run `:TSInstall gleam` to get syntax highlighting and other tree-sitter
 features.
 
+### What About Mason?
+Gleam's toolchain comes bundled with everything in a single binary, including the LSP. 
+This means if you install Gleam using Mason, Neovim gets a second version of Gleam, which 
+can lead to version conflicts between your editor and your actual build.
+
+Because of this, it is recommended to just add the manual configuration line above using `lspconfig`.
+
 ## VS Code
 
 Install the [VS Code Gleam plugin](https://marketplace.visualstudio.com/items?itemName=Gleam.gleam).


### PR DESCRIPTION
This is an attempt to add some clarification for those that are getting started with Gleam in Neovim. 

Mason recommended almost everywhere now days to get started with Neovim and its LSP integration. Because of this, new users see the "deprecated" message in Mason about Gleam which adds friction and confusion to the getting started process.


I have also added a PR to Mason to direct people to this page to get more information https://github.com/mason-org/mason-registry/pull/5904 