### PR TITLE
Avoid flickering in logo hover animation

### DIFF
--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -26,12 +26,13 @@
   <div class="hero">
     <div class="content">
       {% if include.image %}
-      <img
-        data-show-pride
-        class="hero-lucy wide-only"
-        src="{{ include.image }}"
-        alt="{{ include.alt }}"
-      />
+      <div class="hero-lucy-container wide-only" data-show-pride>
+        <img
+          class="hero-lucy"
+          src="{{ include.image }}"
+          alt="{{ include.alt }}"
+        />
+      </div>
       {% endif %}
       <div class="text">{{ include.content }}</div>
     </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -201,10 +201,19 @@ main.content {
   margin-right: 0.25em;
 }
 
+.hero-lucy-container {
+  flex-shrink: 0;
+  height: 268px;
+  width: 280px;
+  margin: 0 var(--gap-5) var(--gap-2) var(--gap-5);
+  overflow: hidden;
+  /* Needed to not cut Lucy's corners when rotating: */
+  padding: var(--gap-1);
+  box-sizing: content-box;
+}
 .hero-lucy {
-  height: 307px;
-  width: 400px;
-  padding: var(--gap-1) var(--gap-6) var(--gap-3) var(--gap-6);
+  height: 100%;
+  width: 100%;
   transition: transform 0.2s ease;
 }
 .footer-lucy {
@@ -214,7 +223,7 @@ main.content {
   content: url("/images/lucy/lucyhappy.svg");
   transform: rotate(23deg);
 }
-.hero-lucy:hover {
+.hero-lucy-container:hover .hero-lucy {
   content: url("/images/lucy/lucyhappy.svg");
   transform: rotate(23deg);
 }


### PR DESCRIPTION
As I was about to try Gleam, Lucy shook their head as if I was about to make a big mistake.

https://github.com/gleam-lang/website/assets/2142817/21d7609d-2f27-4169-be64-98c986e41373

This PR adds a container around Lucy, with `overflow: hidden` so the rotation happens without changing the hover boundaries. Also, the hover effect no longer starts in random distances from the logo, by changing some padding to margin.

(For a language that took inspiration from Elm, it’s funny you even copied [having a somewhat glitchy hover effect on your website](https://twitter.com/SimonLydell/status/1756691086892797991) 😄 )