### PR TITLE
Add Android/Termux installation method

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -123,6 +123,16 @@ Gleam is available as part of the official packages repository. Install it with:
 
 There are also nightlies available at this [home project](https://build.opensuse.org/project/show/home:Pi-Cla:gleam-nightly)
 
+### Android
+
+#### Termux
+
+Gleam is available as part of the official packages repository. Install it with:
+
+```
+$ pkg install gleam
+```
+
 ### Windows
 
 #### Using Scoop

--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -129,8 +129,8 @@ There are also nightlies available at this [home project](https://build.opensuse
 
 Gleam is available as part of the official packages repository. Install it with:
 
-```
-$ pkg install gleam
+```sh
+pkg install gleam
 ```
 
 ### Windows


### PR DESCRIPTION
Gleam is now available in the Termux official packages repository as of commit [e9e292](https://github.com/termux/termux-packages/commit/e9e292bfc44381cc8554a5449875f545bd806b1a).