### PR TITLE
Clarify / simplify OpenBSD instructions

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -107,7 +107,7 @@ $ export PATH=/usr/local/lib/erlang23/bin:$PATH
 
 ### OpenBSD
 
-For OpenBSD -current, Gleam is available as a binary package. You can install it with:
+Gleam is available as a binary package. You can install it with:
 
 ```
 $ doas pkg_add gleam


### PR DESCRIPTION
gleam has been available in OpenBSD ports for two releases now, so there's no point in highlighting that it's available in -current.