### PR TITLE
Fix typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ alt="Lucy the star, Gleam's mascot" content=header_content %}
 
   <section class="home-top-sponsors">
     <div class="content">
-      <h2>Kindly supported by sponors like you!</h2>
+      <h2>Kindly supported by sponsors like you!</h2>
       <a
         class="sponsor-level0"
         href="https://github.com/sponsors/lpil"


### PR DESCRIPTION
"sponsors" is misspelled as "sponors"