### PR TITLE
Adds heading for Elixir Cheatsheet ToC to link to

### DIFF
--- a/cheatsheets/gleam-for-elixir-users.md
+++ b/cheatsheets/gleam-for-elixir-users.md
@@ -582,6 +582,8 @@ dict.from_list([#("key1", "value1"), #("key2", 2)]) // Type error!
 
 Custom type allows you to define a collection data type with a fixed number of named fields, and the values in those fields can be of differing types.
 
+### Records
+
 #### Elixir
 
 Elixir uses Structs which are implemented using Erlang's Map.


### PR DESCRIPTION
Right now, on the live site the 'Records' item in the elixir cheat sheet table of contents does not work because there is no `### Records` in the document.