### PR TITLE
Fix Typo in "Supercharged Labels"

### DIFF
--- a/_posts/2024-08-02-supercharged-labels.md
+++ b/_posts/2024-08-02-supercharged-labels.md
@@ -48,7 +48,7 @@ The shorthand can be used for labelled record fields and in pattern matching
 too.
 
 ```gleam
-pub fn get_year(data: Date) -> Year {
+pub fn get_year(date: Date) -> Year {
   let Date(year:, ..) = date
   year
 }


### PR DESCRIPTION
Currently, [the post](https://gleam.run/news/supercharged-labels/) reads:


> The shorthand can be used for labelled record fields and in pattern matching too.
> ```gleam
> pub fn get_year(data: Date) -> Year {
>   let Date(year:, ..) = date
>   year
> }
> ```

I haven't ran this code, but I would anticipate that the parameter was supposed to be "date" and not "data".

Feel free to disregard this PR if I'm missing something.