### PR TITLE
Update 2024-08-02-supercharged-labels.md

### DIFF
--- a/_posts/2024-08-02-supercharged-labels.md
+++ b/_posts/2024-08-02-supercharged-labels.md
@@ -253,7 +253,7 @@ large file. This was added by [PgBiel](https://github.com/PgBiel), thank you!
 ## Case correction
 
 Gleam uses `snake_case` for variables and functions, and `PascalCase` for types
-and record constructors. Using a different case is a compile error, so you're
+and record constructors. Using a different case is a compile error, so you'll
 never have an argument about which case to use in Gleam!
 
 In the event you accidentally use the wrong one the language server now suggests


### PR DESCRIPTION
Changed a tiny tiny typo under the case correction section from you're to you'll, feel free to shut me down and explain how the previous instance was more correct! This is my first ever github change so I could be wrong.