### PR TITLE
fix: typo in a table of content

### DIFF
--- a/language-server.md
+++ b/language-server.md
@@ -24,7 +24,7 @@ This document details the current state of the language server and its features.
   - [Go-to definition](#go-to-definition)
   - [Code completion](#code-completion)
   - [Document symbols](#document-symbols)
-  - [Document symbols](#document-symbols)
+  - [Signature help](#signature-help)
   - [Code Actions](#code-actions)
     - [Case correction](#case-correction)
     - [Fill labels](#fill-labels)


### PR DESCRIPTION
A link to the "Document symbols" section was duplicated while a link to the "Signature help" section was absent.