### PR TITLE
writing-gleam docs: Correct import internal statements and remove unnecessary escript creation step

### DIFF
--- a/writing-gleam.md
+++ b/writing-gleam.md
@@ -227,7 +227,7 @@ import argv
 import envoy
 import gleam/io
 import gleam/result
-import vars/internal
+import internal
 
 pub fn main() {
   // Omitted for brevity
@@ -250,7 +250,7 @@ Open up the `test/vars_test.gleam` file and write a test for the `format_pair`.
 // in test/vars_test.gleam
 import gleeunit
 import gleeunit/should
-import vars/internal
+import internal
 
 pub fn main() {
   gleeunit.main()

--- a/writing-gleam.md
+++ b/writing-gleam.md
@@ -300,9 +300,6 @@ file, which will be written to `./vars`.
 # Compile the program to an escript
 gleam run -m gleescript
 
-# Make the escript executable
-chmod +x ./vars
-
 # Run the program
 ./vars get USER
 escript ./vars get USER # On Windows


### PR DESCRIPTION
When hand coding through writing-gleam page,the 
import vars/internal 
statement generated a not found error. If the LSP was used to automatically generate the import statement it became
import internal
This pull request changes the two usages of 
import vars/internal
to
import internal

After I created the ./vars escript I noticed it had been created with executable rights so that step is not required on  linux.