### PR TITLE
All lives matter then

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@ It has these fields:
       </p>
       <p>
         <!-- Hello! If you make a PR changing this I will ban you. -->
-        Black lives matter. Trans rights are human rights. No nazi bullsh*t.
+        Black lives matter. White lives matter. Trans rights are human rights. Straight rights are human rights. No nazi bullsh*t.
       </p>
     </div>
     <!-- TODO: add Lucy here -->


### PR DESCRIPTION
I think it's right to either highlights all groups of people or none. 

Just: "As a community, we want to be friendly, too. People from around the world, of all backgrounds, genders, and experience levels are welcome and respected equally. See our community code of conduct for more." would be enough.

But if you want to add more, then please mention all groups of people. 
Otherwise, it seems not very welcoming for straight people like me.

It either both or none to make it really friendly.