### PR TITLE
make gleam homepage title a bit more specific

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -2,7 +2,9 @@
 <html lang="en-GB">
   <head>
     <!-- prettier-ignore -->
-    {%- capture title -%}{% if page.title %}{{ page.title | strip }} – {% endif %}Gleam{%- endcapture -%}
+    {%- capture default_title -%}Gleam Language{%- endcapture -%}
+    <!-- prettier-ignore -->
+    {%- capture title -%}{% if page.title %}{{ page.title | strip }} - Gleam{% else %}{{ default_title }}{% endif %}{%- endcapture -%}
     <!-- prettier-ignore -->
     {%- capture default_description -%}The Gleam programming language{%- endcapture -%}
     <!-- prettier-ignore -->


### PR DESCRIPTION
I think adding a title that specifies "Language" looks better in search engines.

How it looks on the web now:
It just says "Gleam"
<img width="704" alt="image" src="https://github.com/user-attachments/assets/e58670d9-4cc9-458c-8eb6-60840b92a71a">

**Comparisons**
Competing search result for "gleam":
<img width="661" alt="image" src="https://github.com/user-attachments/assets/63297a7c-27bd-4c23-8f5d-575a0f6c1940">

golang:
<img width="679" alt="image" src="https://github.com/user-attachments/assets/a69e08d6-8903-4da0-9e0f-b6def7558333">

Rust:
<img width="670" alt="image" src="https://github.com/user-attachments/assets/fe31fa65-553f-4f3b-8dc1-45715d5bdb88">

Haskell:
<img width="682" alt="image" src="https://github.com/user-attachments/assets/7855278c-169a-47b0-a91d-8507e6c5ca95">

I chose to go with "Gleam Language" (just like Haskell does) because the name still fits nicely in the title bar. Other pages remain unchanged, they still append "- Gleam" after their title.