### PR TITLE
Update fly.md

### DIFF
--- a/deployment/fly.md
+++ b/deployment/fly.md
@@ -29,7 +29,7 @@ defines a micro web application.
 ```gleam
 import mist
 import gleam/erlang/process
-import gleam/bytes_builder
+import gleam/bytes_tree
 import gleam/http/response.{Response}
 
 pub fn main() {
@@ -42,7 +42,7 @@ pub fn main() {
 }
 
 fn web_service(_request) {
-  let body = bytes_builder.from_string("Hello, Joe!")
+  let body = bytes_tree.from_string("Hello, Joe!")
   Response(200, [], mist.Bytes(body))
 }
 ```


### PR DESCRIPTION
bytes_builder was deprecated in gleam_stdlib 0.47.0 and has since been removed

https://hexdocs.pm/gleam_stdlib/0.47.0/gleam/bytes_builder.html#BytesBuilder

Before the change, the example failed to build.
```log
my_web_app\src\my_web_app.gleam:1:1
  │
1 │ import gleam/bytes_builder
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^

No module has been found with the name `gleam/bytes_builder`.

error: Unknown module
   ┌─ C:\Users\phillipsdo\repos\gleam-my_web_app\src\my_web_app.gleam:16:14
   │
16 │   let body = bytes_builder.from_String("Ahoy, world!")
   │              ^^^^^^^^^^^^^

No module has been found with the name `bytes_builder`.
```