### PR TITLE
Fix typo in v1.7.0 announcement

### DIFF
--- a/_posts/2025-01-05-improved-performance-and-publishing.md
+++ b/_posts/2025-01-05-improved-performance-and-publishing.md
@@ -422,7 +422,7 @@ pub fn main() {
 }
 ```
 
-Triggering the code action result in the function-capture being expanded to the
+Triggering the code action results in the function-capture being expanded to the
 full anonymous function syntax:
 
 ```gleam


### PR DESCRIPTION
Fixes a small typo.

IMO it would also read nicer as
```diff
- Triggering the code action result in the function-capture being expanded to the full anonymous function syntax:
+ Triggering the code action expands the function-capture to the full anonymous function syntax
```
but it's not a big difference.
