### PR TITLE
Fix typo related to language tour

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -8,7 +8,7 @@ layout: page
 
 - [Language tour](https://tour.gleam.run)
 
-  An in-browser interactive introduction the teaches the whole language.
+  An in-browser interactive introduction that teaches the whole language.
 
 - [Writing Gleam](/writing-gleam)
   


### PR DESCRIPTION
A very small typo that caught my eye on the documentation page:

```diff
-  An in-browser interactive introduction the teaches the whole language.
+  An in-browser interactive introduction that teaches the whole language.
```