### PR TITLE
Update roadmap for new release

### DIFF
--- a/_data/roadmap.yml
+++ b/_data/roadmap.yml
@@ -6,13 +6,6 @@ in-progress:
   - Improved dependency versions conflict error messages
   - JavaScript sourcemaps
   - Unaligned bit array support on JavaScript
-  - Language server label completion
-  - Fault tolerant parsing of `case` expressions
-  - Fault tolerant analysis of pipelines
-  - Support OTP27 doc comments
-  - Langauge server generate function code action
-  - Langauge server pattern match on value code action
-  - Language server rename variable code action
 planned:
   - Dead code detection improvements
   - Hex private package support
@@ -34,6 +27,16 @@ research:
   - Test discovery functionality
   - Build tool watch mode
 done:
+  - version: v1.8
+    date: 2025-02-07
+    items:
+      - Language server label completion
+      - Fault tolerant parsing of `case` expressions
+      - Fault tolerant analysis of pipelines
+      - Support OTP27 doc comments
+      - Langauge server generate function code action
+      - Langauge server pattern match on value code action
+      - Language server rename variable code action
   - version: v1.7
     date: 2025-01-05
     items:

--- a/_posts/2025-02-07-gleam-gets-rename-variable.md
+++ b/_posts/2025-02-07-gleam-gets-rename-variable.md
@@ -1,7 +1,7 @@
 ---
 author: Louis Pilfold
 author-link: https://github.com/lpil
-title: Gleam gets ‟rename variable”
+title: Gleam gets “rename variable”
 subtitle: Gleam v1.8.0 released
 tags:
   - Release
@@ -50,7 +50,7 @@ feature!
 Erlang OTP27 added the `-doc` attribute, a new standard for adding documentation
 to Erlang based code. The documentation for functions with this attribute can be
 programmatically accessed, for example using the documentation helper in the
-Erlang and Elixir REPLs. 
+Erlang and Elixir REPLs.
 
 ```txt
 Eshell V15.1.3 (press Ctrl+G to abort, type help(). for help)
@@ -156,6 +156,7 @@ pub fn greet_logged_user() {
   "Hello!"
 }
 ```
+
 ```txt
 error: Type mismatch
   ┌─ /main.gleam:7:3
@@ -171,6 +172,7 @@ Found type:
 
     String
 ```
+
 Thank you Jak!
 
 ## `gleam deps tree`
@@ -283,7 +285,6 @@ For full details of the many fixes and improvements they've implemented see [the
 changelog][changelog].
 
 [changelog]: https://github.com/gleam-lang/gleam/blob/main/changelog/v1.8.md
-
 
 ## A call for support
 


### PR DESCRIPTION
I've updated the roadmap to include v1.8, I've also changed the double quotes in the title of the v1.8 announcement post as the opening one looked odd:
![image](https://github.com/user-attachments/assets/eeca6491-00d3-44d4-82db-62fc14eb18ef)
