### PR TITLE
Add Fedora installation instructions for Gleam to documentation

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -102,6 +102,15 @@ Gleam is available as part of the official packages repository. Install it with:
 sudo xbps-install gleam
 ```
 
+#### Fedora
+
+You can install Gleam on Fedora using the DNF package manager. Run the following command:
+
+```sh
+sudo dnf copr enable frostyx/gleam
+sudo dnf install gleam
+```
+
 ### FreeBSD
 
 Gleam is available in ports, and also in binary packages. You may need


### PR DESCRIPTION
This pull request adds installation instructions for Fedora to the Gleam documentation. It includes steps to enable the `frostyx/gleam` COPR repository and install Gleam using the `dnf` package manager. This update ensures that Fedora users have clear instructions for setting up Gleam development on their systems.