### PR TITLE
Remove mention of nightlies

### DIFF
--- a/getting-started/installing.md
+++ b/getting-started/installing.md
@@ -139,8 +139,6 @@ Gleam is available as part of the official packages repository. Install it with:
 # zypper install gleam
 ```
 
-There are also nightlies available at this [home project](https://build.opensuse.org/project/show/home:Pi-Cla:gleam-nightly)
-
 ### Android
 
 #### Termux


### PR DESCRIPTION
I have not been updating the openSUSE nightlies repo to be actual nightly builds for a while now. Going to retire it