### PR TITLE
Updated fly deployment guide

### DIFF
--- a/deployment/fly.md
+++ b/deployment/fly.md
@@ -37,6 +37,7 @@ pub fn main() {
     web_service
     |> mist.new
     |> mist.port(8080)
+    |> mist.bind("0.0.0.0")
     |> mist.start_http
   process.sleep_forever()
 }
@@ -47,9 +48,8 @@ fn web_service(_request) {
 }
 ```
 
-Now we have a web application that listens on port 8080 and can be started with
+Now we have a web application that listens on 0.0.0.0 with port 8080 and can be started with
 `gleam run`.
-
 
 ## Add a Dockerfile
 


### PR DESCRIPTION
After following the guide, I noticed the fly deployment wasn't working and fly was complaining in the logs that the application was only listening on `127.0.0.1` instead of `0.0.0.0`.