### PR TITLE
feat: add link to Branding page to the footer

### DIFF
--- a/_layouts/layout.html
+++ b/_layouts/layout.html
@@ -74,6 +74,7 @@
           <li><a href="https://packages.gleam.run/">Packages</a></li>
           <li><a href="https://gleamweekly.com/">Gleam Weekly</a></li>
           <li><a href="/roadmap">Roadmap</a></li>
+          <li><a href="/branding">Branding</a></li>
         </ul>
         <ul class="last">
           <li>&copy; {{ site.time | date: '%Y' }} Louis Pilfold</li>


### PR DESCRIPTION
Closes #485
# Description
Add link to [Branding page](https://gleam.run/branding/) to the footer. In issue I explaned why this is reasonable for me
# Screenshots
![image](https://github.com/user-attachments/assets/c996deb4-1110-4736-aa0c-4eb5a954573a)
