### PR TITLE
Fix git SSH urls in gleam.toml example

### DIFF
--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -2325,8 +2325,8 @@ gleam_http = \">= 2.1.0 and < 3.0.0\"
 # Local dependencies can be specified with a path
 my_other_project = { path = \"../my_other_project\" }
 # Git dependencies can also be used
-my_git_library = { git = \"git@github.com/my-project/my-library\", ref = \"a8b3c5d82\" }
-latest_stdlib = { git = \"git@github.com/gleam-lang/stdlib\", ref = \"main\" }
+my_git_library = { git = \"git@github.com:my-project/my-library\", ref = \"a8b3c5d82\" }
+latest_stdlib = { git = \"git@github.com:gleam-lang/stdlib\", ref = \"main\" }
 
 # The Hex packages the project needs for the tests (optional)
 # These will not be included if the package is published to Hex.


### PR DESCRIPTION
They were using `git@github.com/...` when they should be `git@github.com:...`.
(Combined with https://github.com/gleam-lang/gleam/issues/4492 this has been causing confusion lately.)