### PR TITLE
Disambiguate 2nd paragraph under 'Reliable and scalable'

### DIFF
--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -3508,7 +3508,7 @@ pub fn main() {
           ]),
           html.p([], [
             html.text(
-              "Thanks to a multi-core actor based concurrency system that can run
+              "Thanks to it's multi-core actor based concurrency system that can run
               millions of concurrent tasks, fast immutable data structures, and a
               concurrent garbage collector that never stops the world, your service
               can scale and stay lightning fast with ease.",

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -3508,7 +3508,7 @@ pub fn main() {
           ]),
           html.p([], [
             html.text(
-              "Thanks to it's multi-core actor based concurrency system that can run
+              "Thanks to its multi-core actor based concurrency system that can run
               millions of concurrent tasks, fast immutable data structures, and a
               concurrent garbage collector that never stops the world, your service
               can scale and stay lightning fast with ease.",


### PR DESCRIPTION
I was talking to other people about gleam and they got a little confused about gleams concurrency.


In their words:
> It's one of those new age erlang vm languages with "better concurrency"

After clearing the confusion they elaborated on what caused them to think that:

> I'd assume that if they were talking about the erlang vm, they'd say "its" or "BEAMs", instead of "a". 

So i swapped "a" to "it's" 
