### PR TITLE
add information about git-deps to writing-gleam/#adding-dependencies

### DIFF
--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -1074,27 +1074,20 @@ compatible with your version constraints you can run ",
 my_other_package = { path = \"../my_other_package\" }
 ",
     ),
-    html.p([], [
-      html.text(
-        "As well as git dependencies.",
-      ),
-    ]),
+    html.p([], [html.text("As well as git dependencies.")]),
     highlighted_toml_pre_code(
       "[dependencies]
 my_git_library = { git = \"git@github.com:my-project/my-library\", ref = \"a8b3c5d82\" }
 latest_stdlib = { git = \"git@github.com:gleam-lang/stdlib\", ref = \"main\" }
 ",
     ),
-        html.p([],[
+    html.p([], [
       html.text("See: "),
       html.a([attr.href("https://gleam.run/writing-gleam/gleam-toml")], [
         html.text("gleam.toml"),
       ]),
       html.text(" definition for more information."),
-        ]),
-
-
-
+    ]),
     html.h2([attr.id("using-dependencies")], [html.text("Using dependencies")]),
     html.p([], [
       html.text("The "),

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -1066,8 +1066,7 @@ compatible with your version constraints you can run ",
     ]),
     html.p([], [
       html.text(
-        "You can also use path dependencies to depend on packages on your computer rather
-than from Hex.",
+        "You can also use path dependencies to depend on packages on your computer rather than from Hex.",
       ),
     ]),
     highlighted_toml_pre_code(
@@ -1075,6 +1074,27 @@ than from Hex.",
 my_other_package = { path = \"../my_other_package\" }
 ",
     ),
+    html.p([], [
+      html.text(
+        "As well as git dependencies.",
+      ),
+    ]),
+    highlighted_toml_pre_code(
+      "[dependencies]
+my_git_library = { git = \"git@github.com:my-project/my-library\", ref = \"a8b3c5d82\" }
+latest_stdlib = { git = \"git@github.com:gleam-lang/stdlib\", ref = \"main\" }
+",
+    ),
+        html.p([],[
+      html.text("See: "),
+      html.a([attr.href("https://gleam.run/writing-gleam/gleam-toml")], [
+        html.text("gleam.toml"),
+      ]),
+      html.text(" definition for more information."),
+        ]),
+
+
+
     html.h2([attr.id("using-dependencies")], [html.text("Using dependencies")]),
     html.p([], [
       html.text("The "),


### PR DESCRIPTION
It came up in discord#general that there is no reference about git-deps in https://gleam.run/writing-gleam/#adding-dependencies so i added some basic information and a reference to the gleam.toml definition.