### PR TITLE
Correct Zed LSP steps

### DIFF
--- a/src/website/language_server.gleam
+++ b/src/website/language_server.gleam
@@ -1255,9 +1255,7 @@ fn zed_installation_html() -> List(Element(Nil)) {
   [
     html.p([], [
       html.text(
-        "Zed supports the language server out-of-the-box. No additional configuration
-is required and Zed will automatically start the language server when a Gleam
-file is opened.",
+        "When a Gleam file is opened, Zed will suggest to install the Gleam plugin, once installed the language server will automatically be started when you open a Gleam file.",
       ),
     ]),
   ]


### PR DESCRIPTION
It seems the Zed Editor has changed Gleam support to now be in a plugin, showing this prompt on first opening a Gleam file:

![Zoom in to prompt](https://github.com/user-attachments/assets/afb9eb62-a6c5-4077-8aef-f5f42e625b37)

This installs the following plugin:
![plugin entry in search](https://github.com/user-attachments/assets/2b82c1bf-1ed3-4ea6-8d10-d5eadbbac1c1)

And only after downloading that plugin the LSP works.


So I reflected that change in this PR :)