### PR TITLE
Centre hero text when not on the homepage

### DIFF
--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -383,7 +383,8 @@ main.content {
 
 .sponsor-level0 img {
   transition: transform 100ms ease-in-out;
-  height: 110px;
+  max-height: 110px;
+  max-width: 100%;
   animation: pulse-animation 2.2s infinite;
   border-radius: 100px;
 }
@@ -406,7 +407,8 @@ main.content {
 }
 
 .sponsor-level1 img {
-  height: 100px;
+  max-height: 110px;
+  max-width: 100%;
 }
 
 .sponsor-level2 img {

--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -163,6 +163,10 @@ td {
   padding: 5px;
 }
 
+.text-left {
+  text-align: left;
+}
+
 .content {
   max-width: 100%;
   width: var(--width-content);
@@ -250,6 +254,7 @@ main.content {
 .hero {
   padding-top: var(--gap-4);
   color: var(--color-blacker);
+  text-align: center;
 }
 
 .hero h1 {

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -3487,7 +3487,7 @@ pub fn home(ctx: site.Context) -> fs.File {
         "Lucy the star, Gleam's mascot",
       )),
       content: [
-        html.div([], [
+        html.div([class("text-left")], [
           html.b([], [html.text("Gleam")]),
           html.text(" is a "),
           html.b([], [html.text("friendly")]),


### PR DESCRIPTION
Hey, short and simple one today to fix some awkward styling across the website. Currently, we always left-align text in the hero (header), which leads to some headings looking a bit off, like this:
![image](https://github.com/user-attachments/assets/3c29c481-a120-4005-9962-623ff55889f6)

This is correct for the homepage though, because it's balanced against Lucy on the left side, so we need a class (text-left) to differentiate it. I've decided to go for a reusable utility class rather than a single-use "hero-home" class or similar.

After this change, here's how page hero text should look:
![image](https://github.com/user-attachments/assets/b88b26ef-2c5c-4039-980f-edcd02a407e0)
