### PR TITLE
Use created user in deployment dockerfile

### DIFF
--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -764,6 +764,7 @@ RUN \\
   addgroup --system webapp && \\
   adduser --system webapp -g webapp
 COPY --from=build /app/build/erlang-shipment /app
+USER webapp
 WORKDIR /app
 ENTRYPOINT [\"/app/entrypoint.sh\"]
 CMD [\"run\"]


### PR DESCRIPTION
The `webapp` user is added but not used, in the docs for deployment on a Linux server