### PR TITLE
Add a dedicated "sponsors" page

### DIFF
--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -1167,7 +1167,6 @@ pre code {
   margin: 0 auto 6rem;
   padding: 0 1rem;
   display: grid;
-  grid-template-columns: 1fr 1fr;
   gap: 2rem;
 }
 
@@ -1184,10 +1183,15 @@ pre code {
   padding: 1.3rem; 
 }
 
-.sponsee:nth-of-type(even) {
-  transform: translateY(30%);
-}
+@media (min-width: 960px) {
+  .sponsees {
+	grid-template-columns: 1fr 1fr;
+  }
 
+  .sponsee:nth-of-type(even) {
+	transform: translateY(30%);
+  }
+}
 .sponsee img {
   width: 4.6rem;
   height: 4.6rem;

--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -29,6 +29,7 @@
   --font-family-title: "Lexend", sans-serif;
   /*--font-family-monospace: "Cascadia Mono" "Roboto Mono", monospace;*/
 
+  --color-cool-charcoal: #1c202b;
   --color-charcoal: #2f2f2f;
   --color-lukewarm-charcoal: #313546;
   --color-warm-charcoal: #616682;
@@ -166,6 +167,14 @@ td {
 
 .text-left {
   text-align: left;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.text-right {
+  text-align: right;
 }
 
 .content {
@@ -1134,4 +1143,86 @@ pre code {
 .case-study-cta p {
   max-width: 40ch;
   margin: .4rem 0 0;
+}
+
+.stacked-articles > article {
+  max-width: 70ch;
+  margin: 0 auto;
+}
+
+.sponsor-page-callout {
+  background-color: var(--color-faff-pink);
+  padding: 6rem 0 4rem;
+  margin: 3rem 0 -3rem;
+  text-align: center;
+  color: var(--color-black);
+}
+
+.sponsor-page-callout h2 {
+  font-weight: var(--font-weight-title-bold);
+}
+
+.sponsees {
+  max-width: 772px;
+  margin: 0 auto 6rem;
+  padding: 0 1rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.sponsee {
+  background: var(--color-lukewarm-charcoal);
+  border: 1px solid var(--color-warm-charcoal);
+  max-width: 400px;
+  width: 100%;
+  border-radius: .6rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: center;
+  padding: 1.3rem; 
+}
+
+.sponsee:nth-of-type(even) {
+  transform: translateY(30%);
+}
+
+.sponsee img {
+  width: 4.6rem;
+  height: 4.6rem;
+  border-radius: 100rem;
+}
+
+.sponsee h4 {
+  font-weight: var(--font-weight-title-bold);
+  color: var(--color-white);
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.sponsee p {
+  margin: 0;
+}
+
+.sponsee .sponsor-button {
+  padding: .9rem 1rem;
+  border-radius: .4rem;
+  background: var(--color-faff-pink);
+  font-weight: var(--font-weight-title-bold);
+  color: var(--color-black);
+  grid-column: 1 / span 2;
+  text-align: center;
+  font-family: var(--font-family-title);
+  transition: opacity 120ms ease-in-out;
+}
+
+.sponsee .sponsor-button:hover {
+  opacity: .9;
+}
+
+.sponsor-faqs {
+  background: var(--color-cool-charcoal);
+  padding: 3rem 0;
+  margin: 2rem 0 6rem;
 }

--- a/src/website.gleam
+++ b/src/website.gleam
@@ -56,6 +56,7 @@ fn build_site() -> snag.Result(Nil) {
     page.deployment_flyio(ctx),
     page.frequently_asked_questions(ctx),
     page.news_index(news_posts, ctx),
+    page.sponsor(ctx),
     roadmap.page(ctx),
     command_line_reference.page(ctx),
     language_server.page(ctx),

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -53,32 +53,33 @@ pub fn sponsor(ctx: site.Context) -> fs.File {
       preload_images: [],
     )
 
-  let sponsees = [
-    Sponsee(
-      name: "Louis Pilfold",
-      title: "Gleam Creator and Lead",
-      avatar: "https://avatars.githubusercontent.com/u/6134406?v=4",
-      sponsor_link: "https://github.com/sponsors/lpil",
-    ),
-    Sponsee(
-      name: "Hayleigh Thompson",
-      title: "Lustre Maintainer",
-      avatar: "https://avatars.githubusercontent.com/u/9001354?v=4",
-      sponsor_link: "https://github.com/sponsors/hayleigh-dot-dev",
-    ),
-    Sponsee(
-      name: "Giacomo \"Jak\" Cavalieri",
-      title: "Real Life Squirrel",
-      avatar: "https://avatars.githubusercontent.com/u/20598369?v=4",
-      sponsor_link: "https://github.com/sponsors/giacomocavalieri",
-    ),
-    Sponsee(
-      name: "Surya \"Gears\" Rose",
-      title: "Compiler Extraordinaire",
-      avatar: "https://avatars.githubusercontent.com/u/40563462?v=4",
-      sponsor_link: "https://github.com/sponsors/GearsDatapacks",
-    ),
-  ]
+  let sponsees =
+    [
+      Sponsee(
+        name: "Louis Pilfold",
+        title: "Gleam Creator and Lead",
+        avatar: "https://avatars.githubusercontent.com/u/6134406?v=4",
+        sponsor_link: "https://github.com/sponsors/lpil",
+      ),
+      Sponsee(
+        name: "Hayleigh Thompson",
+        title: "Lustre Maintainer",
+        avatar: "https://avatars.githubusercontent.com/u/9001354?v=4",
+        sponsor_link: "https://github.com/sponsors/hayleigh-dot-dev",
+      ),
+      Sponsee(
+        name: "Giacomo \"Jak\" Cavalieri",
+        title: "Real Life Squirrel",
+        avatar: "https://avatars.githubusercontent.com/u/20598369?v=4",
+        sponsor_link: "https://github.com/sponsors/giacomocavalieri",
+      ),
+      Sponsee(
+        name: "Surya \"Gears\" Rose",
+        title: "Compiler Extraordinaire",
+        avatar: "https://avatars.githubusercontent.com/u/40563462?v=4",
+        sponsor_link: "https://github.com/sponsors/GearsDatapacks",
+      ),
+    ]
     |> list.map(fn(sponsee) {
       html.li([class("sponsee")], [
         html.img([attr.src(sponsee.avatar)]),

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -52,72 +52,175 @@ pub fn sponsor(ctx: site.Context) -> fs.File {
   let sponsees =
     [
       #(
-        "Louis",
-        "Squirrel Catcher",
+        "Louis Pilfold",
+        "Gleam Creator and Lead",
         "https://avatars.githubusercontent.com/u/6134406?v=4",
         "https://github.com/sponsors/lpil",
       ),
       #(
-        "Louis",
+        "Hayleigh Thompson",
         "Squirrel Catcher",
-        "https://avatars.githubusercontent.com/u/6134406?v=4",
-        "https://github.com/sponsors/lpil",
+        "https://avatars.githubusercontent.com/u/9001354?v=4",
+        "https://github.com/sponsors/hayleigh-dot-dev",
       ),
       #(
-        "Louis",
+        "Giacomo \"Jak\" Cavalieri ",
         "Squirrel Catcher",
-        "https://avatars.githubusercontent.com/u/6134406?v=4",
-        "https://github.com/sponsors/lpil",
+        "https://avatars.githubusercontent.com/u/20598369?v=4",
+        "https://github.com/sponsors/giacomocavalieri",
       ),
       #(
-        "Louis",
+        "Surya \"Gears\" Rose",
         "Squirrel Catcher",
-        "https://avatars.githubusercontent.com/u/6134406?v=4",
-        "https://github.com/sponsors/lpil",
+        "https://avatars.githubusercontent.com/u/40563462?v=4",
+        "https://github.com/sponsors/GearsDatapacks",
       ),
     ]
     |> list.map(fn(sponsee) {
-      html.li([], [
+      html.li([class("sponsee")], [
         html.img([attr.src(sponsee.2)]),
         html.div([], [
           html.h4([], [html.text(sponsee.0)]),
           html.p([], [html.text(sponsee.1)]),
-          html.a([attr.href(sponsee.3)], [html.text("Sponsor")]),
+        ]),
+        html.a([class("sponsor-button"), attr.href(sponsee.3)], [
+          html.text("Sponsor"),
         ]),
       ])
     })
 
   let content = [
-    html.section([], [
-      html.article([class("prose")], [
-        html.h3([], [html.text("Lorem Ipsum is really useful")]),
+    html.section([class("stacked-articles content prose")], [
+      html.article([class("")], [
+        html.h3([], [html.text("Why sponsor Gleam?")]),
         html.p([], [
           html.text(
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis  ullamcorper metus eu ante congue vehicula. Mauris sagittis in sapien sit amet pharetra. Aenean eleifend vehicula leo at varius. Suspendisse  fringilla libero sit amet sagittis congue. Suspendisse rhoncus, eros nec varius tempor.",
+            "Unlike most programming languages, Gleam does not come from any particular tech corporation or academic institution and it is a truly open-source community project. We depend entirely on sponsoring, from both individuals and companies.",
           ),
         ]),
       ]),
-      html.article([class("prose")], [
-        html.h3([], [html.text("Lorem Ipsum is really useful")]),
+      html.article([class("")], [
+        html.h3([], [html.text("What does “sponsoring” mean exactly?")]),
         html.p([], [
           html.text(
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis  ullamcorper metus eu ante congue vehicula. Mauris sagittis in sapien sit amet pharetra. Aenean eleifend vehicula leo at varius. Suspendisse  fringilla libero sit amet sagittis congue. Suspendisse rhoncus, eros nec varius tempor.",
+            "Sponsoring Gleam is supporting financially the Gleam company or core team members.",
           ),
         ]),
+        html.p([], [
+          html.text(
+            "Your contribution helps fund Gleam development. That includes things like paying Louis (Gleam’s creator) a salary, sponsoring other contributors, hiring contractors, and keeping essential infrastructure like the package index running, among other things.",
+          ),
+        ]),
+        html.p([], [
+          html.text("Everything we bring to the language, like "),
+          html.a([attr.href("/news/gleam-javascript-gets-30-percent-faster/")], [
+            html.text("compiled JS getting 30% faster"),
+          ]),
+          html.text(", is possible thanks to the support of our sponsors!"),
+        ]),
+      ]),
+      html.h3([class("text-center")], [
+        html.text("Check out our full "),
+        html.a([attr.href("/roadmap")], [html.text("roadmap")]),
+        html.text(" to see what we have planned next."),
       ]),
     ]),
-    // TODO: Use a real class here
-    html.section([class("home-top-sponsors")], [
-      html.article([class("content prose text-center")], [
-        html.h3([], [html.text("I'm in! How do I sponsor?")]),
+    html.section([class("sponsor-page-callout")], [
+      html.article([class("content text-center")], [
+        html.h2([], [html.text("I'm in! How do I sponsor?")]),
         html.p([], [
           html.text(
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis  ullamcorper metus eu ante congue vehicula. Mauris sagittis in sapien sit amet pharetra. Aenean eleifend vehicula leo at varius. Suspendisse  fringilla libero sit amet sagittis congue. Suspendisse rhoncus, eros nec varius tempor.",
+            "You can support several of the Gleam core team members to support them and their areas of expertise!",
           ),
+        ]),
+        html.p([], [
+          html.text("Meet some of the core team members you can sponsor:"),
         ]),
       ]),
     ]),
     html.section([], [html.ul([class("sponsees")], sponsees)]),
+    html.section([class("sponsor-faqs")], [
+      html.div([class("prose content")], [
+        html.h2([class("text-center")], [
+          html.text("Frequently Asked Questions"),
+        ]),
+        html.article([], [
+          html.h3([], [html.text("What’s the minimum to become a sponsor?")]),
+          html.p([], [
+            html.text(
+              "There’s no such thing as a donation too small (or too big)! Whatever feels right for you, feels right for us.",
+            ),
+          ]),
+          html.p([], [
+            html.text(
+              "Even if it’s just $1/month, it’s one dollar more towards the development of Gleam! Also, the fact that you’re sponsoring Gleam is visible on your GitHub profile, giving the language additional exposure and serving as a signal that you care about it and might encourage others to sponsor Gleam as well 🩷",
+            ),
+          ]),
+        ]),
+        html.article([], [
+          html.h3([], [html.text("How much of my sponsorship goes to Gleam?")]),
+          html.p([], [
+            html.text(
+              "All of it! GitHub Sponsors does not charge any fees for sponsorships from personal accounts. 100% of your contribution goes directly towards Gleam development!",
+            ),
+          ]),
+          html.p([], [
+            html.text("However, if you use different channels (like "),
+            html.a([attr.href("https://liberapay.com/gleam/")], [
+              html.text("Liberapay"),
+            ]),
+            html.text(
+              " - we’re there too!) there are some additional fees and commissions that depend on your payment method.",
+            ),
+          ]),
+        ]),
+        html.article([], [
+          html.h3([], [html.text("Can I sponsor multiple team members?")]),
+          html.p([], [
+            html.text(
+              "Yes! You can sponsor Louis, Hayleigh, Giacomo, Gears, or other core contributors individually through GitHub Sponsors.",
+            ),
+          ]),
+        ]),
+        html.article([], [
+          html.h3([], [html.text("Can my company sponsor Gleam?")]),
+          html.p([], [
+            html.text(
+              "Absolutely! Companies are welcome to sponsor Gleam - contact Louis directly at hello@gleam.run to get in touch about larger sponsorships, feature funding, or consulting opportunities.",
+            ),
+          ]),
+        ]),
+        html.article([], [
+          html.h3([], [
+            html.text("Do I have to commit for a certain period of time?"),
+          ]),
+          html.p([], [
+            html.text(
+              "GitHub sponsorship allows you to select a one-time donation or an ongoing, monthly support (that you can pause at any time) - whatever works for you! That said, steady monthly contributions help us plan our budget more effectively and keep the roadmap predictable.",
+            ),
+          ]),
+        ]),
+        html.article([], [
+          html.h3([], [html.text("How can I change or cancel my sponsorship?")]),
+          html.p([], [
+            html.text(
+              "You can manage, pause, or cancel your sponsorship anytime through your GitHub Sponsors dashboard.",
+            ),
+          ]),
+        ]),
+      ]),
+    ]),
+    html.section([attr.class("home-sponsors")], [
+      html.div([attr.class("content prose")], [
+        html.h2([], [html.text("Lovely people")]),
+        html.p([], [
+          html.text(
+            "Here's some of the wonderful people already supporting Gleam",
+          ),
+        ]),
+      ]),
+      wall_of_sponsors(),
+    ]),
   ]
 
   [

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -40,6 +40,10 @@ pub fn redirect(from: String, to: String) -> fs.File {
   fs.File(path: from, content:)
 }
 
+type Sponsee {
+  Sponsee(name: String, title: String, avatar: String, sponsor_link: String)
+}
+
 pub fn sponsor(ctx: site.Context) -> fs.File {
   let meta =
     PageMeta(
@@ -49,41 +53,40 @@ pub fn sponsor(ctx: site.Context) -> fs.File {
       preload_images: [],
     )
 
-  let sponsees =
-    [
-      #(
-        "Louis Pilfold",
-        "Gleam Creator and Lead",
-        "https://avatars.githubusercontent.com/u/6134406?v=4",
-        "https://github.com/sponsors/lpil",
-      ),
-      #(
-        "Hayleigh Thompson",
-        "Squirrel Catcher",
-        "https://avatars.githubusercontent.com/u/9001354?v=4",
-        "https://github.com/sponsors/hayleigh-dot-dev",
-      ),
-      #(
-        "Giacomo \"Jak\" Cavalieri ",
-        "Squirrel Catcher",
-        "https://avatars.githubusercontent.com/u/20598369?v=4",
-        "https://github.com/sponsors/giacomocavalieri",
-      ),
-      #(
-        "Surya \"Gears\" Rose",
-        "Squirrel Catcher",
-        "https://avatars.githubusercontent.com/u/40563462?v=4",
-        "https://github.com/sponsors/GearsDatapacks",
-      ),
-    ]
+  let sponsees = [
+    Sponsee(
+      name: "Louis Pilfold",
+      title: "Gleam Creator and Lead",
+      avatar: "https://avatars.githubusercontent.com/u/6134406?v=4",
+      sponsor_link: "https://github.com/sponsors/lpil",
+    ),
+    Sponsee(
+      name: "Hayleigh Thompson",
+      title: "Lustre Maintainer",
+      avatar: "https://avatars.githubusercontent.com/u/9001354?v=4",
+      sponsor_link: "https://github.com/sponsors/hayleigh-dot-dev",
+    ),
+    Sponsee(
+      name: "Giacomo \"Jak\" Cavalieri",
+      title: "Real Life Squirrel",
+      avatar: "https://avatars.githubusercontent.com/u/20598369?v=4",
+      sponsor_link: "https://github.com/sponsors/giacomocavalieri",
+    ),
+    Sponsee(
+      name: "Surya \"Gears\" Rose",
+      title: "Compiler Extraordinaire",
+      avatar: "https://avatars.githubusercontent.com/u/40563462?v=4",
+      sponsor_link: "https://github.com/sponsors/GearsDatapacks",
+    ),
+  ]
     |> list.map(fn(sponsee) {
       html.li([class("sponsee")], [
-        html.img([attr.src(sponsee.2)]),
+        html.img([attr.src(sponsee.avatar)]),
         html.div([], [
-          html.h4([], [html.text(sponsee.0)]),
-          html.p([], [html.text(sponsee.1)]),
+          html.h4([], [html.text(sponsee.name)]),
+          html.p([], [html.text(sponsee.title)]),
         ]),
-        html.a([class("sponsor-button"), attr.href(sponsee.3)], [
+        html.a([class("sponsor-button"), attr.href(sponsee.sponsor_link)], [
           html.text("Sponsor"),
         ]),
       ])

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -4104,9 +4104,7 @@ fn header(
         html.div([], [
           html.a([attr.href("/news")], [html.text("News")]),
           html.a([attr.href("/community")], [html.text("Community")]),
-          html.a([attr.href("/sponsor")], [
-            html.text("Sponsor"),
-          ]),
+          html.a([attr.href("/sponsor")], [html.text("Sponsor")]),
         ]),
         html.div([], [
           html.a([attr.href("https://packages.gleam.run")], [

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -40,6 +40,97 @@ pub fn redirect(from: String, to: String) -> fs.File {
   fs.File(path: from, content:)
 }
 
+pub fn sponsor(ctx: site.Context) -> fs.File {
+  let meta =
+    PageMeta(
+      path: "/sponsor",
+      title: "Sponsor Gleam",
+      description: "Support Gleam's development by sponsoring members of our core team!",
+      preload_images: [],
+    )
+
+  let sponsees =
+    [
+      #(
+        "Louis",
+        "Squirrel Catcher",
+        "https://avatars.githubusercontent.com/u/6134406?v=4",
+        "https://github.com/sponsors/lpil",
+      ),
+      #(
+        "Louis",
+        "Squirrel Catcher",
+        "https://avatars.githubusercontent.com/u/6134406?v=4",
+        "https://github.com/sponsors/lpil",
+      ),
+      #(
+        "Louis",
+        "Squirrel Catcher",
+        "https://avatars.githubusercontent.com/u/6134406?v=4",
+        "https://github.com/sponsors/lpil",
+      ),
+      #(
+        "Louis",
+        "Squirrel Catcher",
+        "https://avatars.githubusercontent.com/u/6134406?v=4",
+        "https://github.com/sponsors/lpil",
+      ),
+    ]
+    |> list.map(fn(sponsee) {
+      html.li([], [
+        html.img([attr.src(sponsee.2)]),
+        html.div([], [
+          html.h4([], [html.text(sponsee.0)]),
+          html.p([], [html.text(sponsee.1)]),
+          html.a([attr.href(sponsee.3)], [html.text("Sponsor")]),
+        ]),
+      ])
+    })
+
+  let content = [
+    html.section([], [
+      html.article([class("prose")], [
+        html.h3([], [html.text("Lorem Ipsum is really useful")]),
+        html.p([], [
+          html.text(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis  ullamcorper metus eu ante congue vehicula. Mauris sagittis in sapien sit amet pharetra. Aenean eleifend vehicula leo at varius. Suspendisse  fringilla libero sit amet sagittis congue. Suspendisse rhoncus, eros nec varius tempor.",
+          ),
+        ]),
+      ]),
+      html.article([class("prose")], [
+        html.h3([], [html.text("Lorem Ipsum is really useful")]),
+        html.p([], [
+          html.text(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis  ullamcorper metus eu ante congue vehicula. Mauris sagittis in sapien sit amet pharetra. Aenean eleifend vehicula leo at varius. Suspendisse  fringilla libero sit amet sagittis congue. Suspendisse rhoncus, eros nec varius tempor.",
+          ),
+        ]),
+      ]),
+    ]),
+    // TODO: Use a real class here
+    html.section([class("home-top-sponsors")], [
+      html.article([class("content prose text-center")], [
+        html.h3([], [html.text("I'm in! How do I sponsor?")]),
+        html.p([], [
+          html.text(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis  ullamcorper metus eu ante congue vehicula. Mauris sagittis in sapien sit amet pharetra. Aenean eleifend vehicula leo at varius. Suspendisse  fringilla libero sit amet sagittis congue. Suspendisse rhoncus, eros nec varius tempor.",
+          ),
+        ]),
+      ]),
+    ]),
+    html.section([], [html.ul([class("sponsees")], sponsees)]),
+  ]
+
+  [
+    header(hero_image: option.None, content: [
+      html.h1([], [html.text(meta.title)]),
+      html.p([attr.class("hero-subtitle")], [html.text(meta.description)]),
+    ]),
+    ..content
+  ]
+  |> top_layout(meta, ctx)
+  |> to_html_file(meta)
+}
+
 pub fn case_study(post: case_study.CaseStudy, ctx: site.Context) -> fs.File {
   let meta =
     PageMeta(
@@ -3906,7 +3997,7 @@ fn header(
         html.div([], [
           html.a([attr.href("/news")], [html.text("News")]),
           html.a([attr.href("/community")], [html.text("Community")]),
-          html.a([attr.href("https://github.com/sponsors/lpil")], [
+          html.a([attr.href("/sponsor")], [
             html.text("Sponsor"),
           ]),
         ]),


### PR DESCRIPTION
G'day Gleam Gang

Today I come bearing a new sponsor page, so we can better highlight more of the wonderful core team and give people some more information about sponsoring! The job titles are a little silly, so make sure you're okay with them haha

Here's a little 1080p screenshot of the full page. Shoutout to @Kamila-P for the copy for the page.

<img width="1920" height="4179" alt="image" src="https://github.com/user-attachments/assets/fc7f221b-75b1-4494-aa81-acee26fd6e77" />

Thanks!!