### PR TITLE
Add a fistful of missing spaces after links

### DIFF
--- a/src/website/language_server.gleam
+++ b/src/website/language_server.gleam
@@ -1295,7 +1295,7 @@ fn neovim_installation_html() -> List(Element(Nil)) {
       html.a([attr.href("https://github.com/neovim/nvim-lspconfig")], [
         html.code([], [html.text("nvim-lspconfig")]),
       ]),
-      html.text("includes configuration for Gleam. Install "),
+      html.text(" includes configuration for Gleam. Install "),
       html.code([], [html.text("nvim-lspconfig")]),
       html.text(
         " with your preferred plugin manager and then add the language server to your ",
@@ -1314,7 +1314,7 @@ fn neovim_installation_html() -> List(Element(Nil)) {
       html.a([attr.href("https://github.com/nvim-treesitter/nvim-treesitter")], [
         html.code([], [html.text("nvim-treesitter")]),
       ]),
-      html.text("you can run "),
+      html.text(" you can run "),
       html.code([], [html.text(":TSInstall gleam")]),
       html.text(" to get syntax highlighting and other tree-sitter features."),
     ]),

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -1641,7 +1641,7 @@ use ETS, the Erlang in-memory key-value database.",
         ],
         [html.code([], [html.text("javascript_mutable_reference")])],
       ),
-      html.text("library offers mutable references."),
+      html.text(" library offers mutable references."),
     ]),
     html.h2([attr.id("does-gleam-have-side-effects")], [
       html.text("Does Gleam have side effects?"),
@@ -1761,7 +1761,7 @@ division by zero which you can use if that is more suitable for your program.",
         html.text("Alpaca"),
       ]),
       html.text(
-        "is similar to Gleam in that it is a statically typed language
+        " is similar to Gleam in that it is a statically typed language
 for the Erlang VM that is inspired by the ML family of languages. It’s a
 wonderful project and it was an early inspiration for Gleam!",
       ),
@@ -1813,7 +1813,7 @@ optionally JavaScript.",
         html.text("Caramel"),
       ]),
       html.text(
-        "is similar to Gleam in that it is a statically typed language
+        " is similar to Gleam in that it is a statically typed language
 for the Erlang VM. It is very cool, especially because of its OCaml heritage!",
       ),
     ]),
@@ -1853,7 +1853,7 @@ family languages.",
         html.text("Elixir"),
       ]),
       html.text(
-        "is another language that runs on the Erlang virtual machine.
+        " is another language that runs on the Erlang virtual machine.
 It is very popular and a great language!",
       ),
     ]),
@@ -1958,7 +1958,7 @@ programming style you personally find most enjoyable and productive.",
         html.text("Purerl"),
       ]),
       html.text(
-        "is a backend for the PureScript compiler that outputs Erlang.
+        " is a backend for the PureScript compiler that outputs Erlang.
 Both PureScript and Purerl are fantastic!",
       ),
     ]),
@@ -2007,7 +2007,7 @@ though not all of it can be used with the Purerl compiler backend.",
         html.text("Rust"),
       ]),
       html.text(
-        "is a language that compiles to native code and gives you full
+        " is a language that compiles to native code and gives you full
 control of memory use in your program, much like C or C++. Gleam’s compiler is
 written in Rust! We’re big fans of the language.",
       ),


### PR DESCRIPTION
I found a few missing spaces on the FAQ page and then poked around some more, but it's probably not exhaustive.