### PR TITLE
fix share button for case studies & fix some styling duplication

### DIFF
--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -1107,7 +1107,8 @@ pre code {
   margin-bottom: 2rem;
 }
 
-.post-meta .meta-button {
+.post-meta .meta-button,
+.case-study-meta .meta-button {
   appearance: normal;
   background: none;
   color: var(--color-text-main);
@@ -1117,7 +1118,9 @@ pre code {
   border-radius: .3rem;
   padding: .6rem;
   display: flex;
+  justify-content: center;
   align-items: center;
+  cursor: pointer;
   gap: .6rem;
   transition-property: color, border-color;
   transition-timing-function: ease-in-out;
@@ -1131,7 +1134,8 @@ pre code {
   cursor: pointer;
 }
 
-.post-meta .meta-button:hover {
+.post-meta .meta-button:hover,
+.case-study-meta .meta-button:hover {
   border-color: var(--color-faff-pink);
   color: #fff;
 }
@@ -1199,24 +1203,6 @@ pre code {
 .case-study-meta li p {
   margin: .4rem 0 0;
   font-size: 1rem;
-}
-
-.case-study-meta .share-button {
-  appearance: normal;
-  background: none;
-  color: var(--color-text-main);
-  font-weight: var(--font-weight-title-bold);
-  font-size: 1rem;
-  border: #616682 1px solid;
-  border-radius: .3rem;
-  padding: .6rem;
-  display: flex;
-  align-items: center;
-  gap: .6rem;
-  transition-property: color, border-color;
-  transition-timing-function: ease-in-out;
-  transition-duration: 120ms;
-  justify-content: center;
 }
 
 .case-study-cta {

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -349,37 +349,7 @@ pub fn case_study(post: case_study.CaseStudy, ctx: site.Context) -> fs.File {
             html.time([], [html.text(short_human_date(post.published))]),
           ]),
         ]),
-        html.button(
-          [
-            attr(
-              "onclick",
-              "window.navigator.clipboard.writeText('https://gleam.run/news/"
-                <> post.path
-                <> "')",
-            ),
-            attr.data("tooltip-position", "right"),
-            attr.data("tooltip-trigger", "click"),
-            attr.aria_label("Copy post URL to clipboard"),
-            class("tooltip-container meta-button share-button"),
-          ],
-          [
-            html.img([
-              attr.width(20),
-              attr.src("/images/share-icon.svg"),
-              attr.alt("Share Icon"),
-            ]),
-            html.text("Share"),
-            html.span(
-              [
-                class("tooltip"),
-                attr.id("share-tooltip"),
-                attr.role("status"),
-                attr.aria_hidden(True),
-              ],
-              [html.text("Copied the post URL!")],
-            ),
-          ],
-        ),
+        share_button(),
       ]),
 
       element.unsafe_raw_html(
@@ -446,37 +416,7 @@ pub fn news_post(post: news.NewsPost, ctx: site.Context) -> fs.File {
           html.text(" by "),
           html.a([attr.href(post.author.url)], [html.text(post.author.name)]),
         ]),
-        html.button(
-          [
-            attr(
-              "onclick",
-              "window.navigator.clipboard.writeText('https://gleam.run/news/"
-                <> post.path
-                <> "')",
-            ),
-            attr.data("tooltip-position", "right"),
-            attr.data("tooltip-trigger", "click"),
-            attr.aria_label("Copy post URL to clipboard"),
-            class("tooltip-container meta-button share-button"),
-          ],
-          [
-            html.img([
-              attr.width(20),
-              attr.src("/images/share-icon.svg"),
-              attr.alt("Share Icon"),
-            ]),
-            html.text("Share"),
-            html.span(
-              [
-                class("tooltip"),
-                attr.id("share-tooltip"),
-                attr.role("status"),
-                attr.aria_hidden(True),
-              ],
-              [html.text("Copied the post URL!")],
-            ),
-          ],
-        ),
+        share_button(),
       ]),
       element.unsafe_raw_html("", "article", [class("prose")], post.content),
     ]),
@@ -4597,4 +4537,36 @@ fn highlighted_yaml_pre_code(code: String) -> Element(d) {
     |> list.intersperse([html.text("\n")])
     |> list.flatten
   html.pre([], [html.code([], html)])
+}
+
+fn share_button() -> Element(a) {
+  html.button(
+    [
+      attr(
+        "onclick",
+        "window.navigator.clipboard.writeText(document.location.href)",
+      ),
+      attr.data("tooltip-position", "right"),
+      attr.data("tooltip-trigger", "click"),
+      attr.aria_label("Copy post URL to clipboard"),
+      class("tooltip-container meta-button share-button"),
+    ],
+    [
+      html.img([
+        attr.width(20),
+        attr.src("/images/share-icon.svg"),
+        attr.alt("Share Icon"),
+      ]),
+      html.text("Share"),
+      html.span(
+        [
+          class("tooltip"),
+          attr.id("share-tooltip"),
+          attr.role("status"),
+          attr.aria_hidden(True),
+        ],
+        [html.text("Copied the post URL!")],
+      ),
+    ],
+  )
 }

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -353,19 +353,31 @@ pub fn case_study(post: case_study.CaseStudy, ctx: site.Context) -> fs.File {
           [
             attr(
               "onclick",
-              "window.navigator.clipboard.writeText('https://gleam.run/case-studies/"
+              "window.navigator.clipboard.writeText('https://gleam.run/news/"
                 <> post.path
                 <> "')",
             ),
-            class("share-button"),
+            attr.data("tooltip-position", "right"),
+            attr.data("tooltip-trigger", "click"),
+            attr.aria_label("Copy post URL to clipboard"),
+            class("tooltip-container meta-button share-button"),
           ],
           [
             html.img([
               attr.width(20),
               attr.src("/images/share-icon.svg"),
-              attr.alt("Return Icon"),
+              attr.alt("Share Icon"),
             ]),
             html.text("Share"),
+            html.span(
+              [
+                class("tooltip"),
+                attr.id("share-tooltip"),
+                attr.role("status"),
+                attr.aria_hidden(True),
+              ],
+              [html.text("Copied the post URL!")],
+            ),
           ],
         ),
       ]),
@@ -451,7 +463,7 @@ pub fn news_post(post: news.NewsPost, ctx: site.Context) -> fs.File {
             html.img([
               attr.width(20),
               attr.src("/images/share-icon.svg"),
-              attr.alt("Return Icon"),
+              attr.alt("Share Icon"),
             ]),
             html.text("Share"),
             html.span(


### PR DESCRIPTION
Very silly mistake I've made here. The share button was only updated for the news pages, not the case study.

Have also removed some duplicated styling.