### PR TITLE
Add the open-quote on case-study view mobile

### DIFF
--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -1150,14 +1150,24 @@ pre code {
 }
 
 .case-study-quote:before {
-  position: absolute;
-  left: -4rem;
+  position: relative;
+  top: 1rem;
   font-family: var(--font-family-title);
   font-weight: var(--font-weight-title-bold);
-  top: -1rem;
-  font-size: 5rem;
+  font-size: 4rem;
   content: open-quote;
   color: var(--color-warm-charcoal);
+  display: inline-block;
+  margin-right: .4rem;
+}
+
+@media (min-width: 960px) {
+  .case-study-quote:before {
+    position: absolute;
+    left: -4rem;
+    top: -1rem;
+    font-size: 5rem;
+  }
 }
 
 .case-study-quote p {

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -313,7 +313,7 @@ pub fn case_study(post: case_study.CaseStudy, ctx: site.Context) -> fs.File {
   [
     html.div([class("")], [
       html.blockquote([class("case-study-quote")], [
-        html.p([], [html.text(post.featured_quote)]),
+        html.text(post.featured_quote),
       ]),
       html.ul([class("case-study-meta")], [
         html.li([], [


### PR DESCRIPTION
Bit of an oversight, seems I was looking at this long enough I didn't really see how odd it looked to not have the quotation mark on mobile. Alas, she returns:

<img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/a840f7be-d70b-46aa-a5ba-1695f8edfb4c" />
