### PR TITLE
Reorder install instructions for Brew & openSUSE

### DIFF
--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -612,6 +612,13 @@ sudo dnf install gleam
         ),
       ]),
     ]),
+    html.h4([attr.id("opensuse")], [html.text("openSUSE")]),
+    html.p([], [
+      html.text(
+        "Gleam is available as part of the official packages repository. Install it with:",
+      ),
+    ]),
+    html.pre([], [html.code([], [html.text("zypper install gleam")])]),
     html.h4([attr.id("using-homebrew-1")], [html.text("Using Homebrew")]),
     html.p([], [
       html.text("With "),
@@ -657,13 +664,6 @@ $ export PATH=/usr/local/lib/erlang23/bin:$PATH
       ),
     ]),
     html.pre([], [html.code([], [html.text("doas pkg_add gleam")])]),
-    html.h3([attr.id("opensuse")], [html.text("openSUSE")]),
-    html.p([], [
-      html.text(
-        "Gleam is available as part of the official packages repository. Install it with:",
-      ),
-    ]),
-    html.pre([], [html.code([], [html.text("zypper install gleam")])]),
     html.h3([attr.id("android")], [html.text("Android")]),
     html.h4([attr.id("termux")], [html.text("Termux")]),
     html.p([], [


### PR DESCRIPTION
I've noticed that the instructions for openSUSE were not in the "Linux section" next to the other Linuxes so I've moved them to the appropriate section. (Below the other distributions as openSUSE is probably not used as much as the others.)

While doing that I've moved the Homebrew for Linux instructions into the Linux section as well as I assume they were accidently sandwiched inbetween the BSDs.