### PR TITLE
add alert widgets

### DIFF
--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -1107,6 +1107,43 @@ pre code {
   max-width: 100%;
 }
 
+.prose .alert {
+  border-left: 3px solid var(--alert-color);
+  padding: 1rem 1.4rem;
+  margin: .8rem 0;
+}
+
+.prose .alert h3 {
+  color: var(--alert-color);
+  margin: 0 0 .4rem;
+  font-size: 1em;
+}
+
+.prose .alert h3:before {
+  content: var(--alert-emoji);
+  margin-right: .8ch;
+}
+
+.prose .alert p {
+  margin: 0;
+  line-height: 1.4;
+}
+
+.prose .alert-info {
+  --alert-color: #5facff;
+  --alert-emoji: 'ℹ️';
+}
+
+.prose .alert-error {
+  --alert-color: #ff5f5f;
+  --alert-emoji: '❗';
+}
+
+.prose .alert-warning {
+  --alert-color: #ffc55f;
+  --alert-emoji: '🔔';
+}
+
 /* Article Meta bar - Including publish date, author, and share button */
 .post-meta {
   display: flex;


### PR DESCRIPTION
Simple one to style Github-style alerts, eg:

> [!TIP]
> Accept my PRs 

I haven't included this as there is no use yet and my code is frankly quite bad but this is incredibly easy to support (at least in a rudimentary form, with my ugly and likely slow example) from Djot markup also, eg:

```gleam
const input = "> [!INFO] This is an informational title
> This is some content

> [!TIP]
This is a tip"

fn alert_title(level: String, content: String) {
  let #(title, content) = case content {
    "\n" <> rest -> #(level, rest)
    _ -> string.split_once(content, "\n") |> result.unwrap(#(level, content))
  }

  jot.RawBlock(
    "<div class=\"alert alert-"
    <> string.lowercase(level)
    <> "\"><h3>"
    <> string.trim(title)
    <> "</h3><p>"
    <> string.trim(content)
    <> "</p></div>",
  )
}

pub fn djot_title_test() {
  let doc =
    input
    |> jot.parse()

  doc.content
  |> list.map(fn(i) {
    case i {
      jot.BlockQuote(
        items: [jot.Paragraph(content: [jot.Text("[!INFO]" <> content)], ..)],
        ..,
      ) -> alert_title("Info", content)
      jot.BlockQuote(
        items: [jot.Paragraph(content: [jot.Text("[!TIP]" <> content)], ..)],
        ..,
      ) -> alert_title("Tip", content)
      _ -> i
    }
  })
}
```