### PR TITLE
Minor fixes to gleam.toml documentation

### DIFF
--- a/documentation/gleam-toml.djot
+++ b/documentation/gleam-toml.djot
@@ -101,7 +101,7 @@ attacks from malicious actors.
 gleeunit = ">= 1.0.0 and < 2.0.0"
 ```
 
-The dependency packages needed only for tests, using the same syntax as the
+The dependency packages needed only during development, using the same syntax as the
 `dependencies` field.
 
 These dependencies are not included if the package is published to Hex. A

--- a/documentation/gleam-toml.djot
+++ b/documentation/gleam-toml.djot
@@ -89,9 +89,10 @@ my_library = {
 ```
 
 Gleam packages available via git can be added as dependencies using the `git`
-field. Always prefer a commit sha reference over a branch or tag reference to
-ensure you get the expected version of the code, and to prevent attacks from
-malicious actors.
+and `ref` fields. Always prefer a commit sha reference over a branch or tag
+reference to ensure you get the expected version of the code, and to prevent
+attacks from malicious actors.
+>>>>>>> 94165e5 (fix git dependency incorrect field name)
 
 ### `dev_dependencies`
 

--- a/documentation/gleam-toml.djot
+++ b/documentation/gleam-toml.djot
@@ -92,7 +92,6 @@ Gleam packages available via git can be added as dependencies using the `git`
 and `ref` fields. Always prefer a commit sha reference over a branch or tag
 reference to ensure you get the expected version of the code, and to prevent
 attacks from malicious actors.
->>>>>>> 94165e5 (fix git dependency incorrect field name)
 
 ### `dev_dependencies`
 

--- a/documentation/gleam-toml.djot
+++ b/documentation/gleam-toml.djot
@@ -238,7 +238,7 @@ they are not public there is no stability or behavioural guarantees for them.
 You may wish to use internal modules for helper modules that are used by your
 public modules.
 
-This field list of [glob patterns](<https://docs.rs/glob/latest/glob/struct.Pattern.html>),
+This field list of [glob patterns](https://docs.rs/glob/latest/glob/struct.Pattern.html),
 and any module names that match one of the glob patterns are marked as internal.
 
 If not given then the default value for this field is


### PR DESCRIPTION
Hi there!

Amazing work on the gleam.toml documentation, just wanted to nitpick a little:

- **fix git dependency incorrect field name**
  - Git dependencies use the `git` and `ref` fields, not the `path` field
- **fix incorrect wording in dev dependencies description**
  - Dev dependencies were described as "used in tests" - that's not true, they're used in development. Tools like squirrel and lustre_dev_tools are also used as dev dependencies
- **fix invalid link in internal modules**
  - There were angle brackets around the link - these made the link unclickable
