### PR TITLE
Document place for external tools' config in `gleam.toml`

### DIFF
--- a/documentation/gleam-toml.djot
+++ b/documentation/gleam-toml.djot
@@ -14,7 +14,7 @@ gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 gleeunit = ">= 1.0.0 and < 2.0.0"
 ```
 
-## Project metadata 
+## Project metadata
 
 ### `name`
 
@@ -335,3 +335,16 @@ allow_write = ["./database.sqlite"]
 
 - `allow_write`: The file system write access to allow. This can be either a
   boolean or a list of paths.
+
+## External tools
+
+### `tools`
+
+```toml
+[tools.my_tool]
+enable = true
+threads = 8
+```
+
+Here you can place data or configuration for external tools. We encourage
+authors of such tools to place configuration under `tools.<tool_name>`.


### PR DESCRIPTION
* Closes #603.

I believe that explanation and example are good enough