### PR TITLE
Fix invalid Elixir block syntax in Gleam for Elixir users cheatsheet

### DIFF
--- a/src/website/cheatsheet.gleam
+++ b/src/website/cheatsheet.gleam
@@ -919,21 +919,31 @@ fn main() {
     html.h2([attr.id("blocks")], [html.text("Blocks")]),
     html.h4([attr.id("elixir-12")], [html.text("Elixir")]),
     html.p([], [
-      html.text("In Elixir expressions can be grouped using "),
+      html.text(
+        "In Elixir expressions can be grouped using parentheses. The ",
+      ),
       html.code([], [html.text("do")]),
-      html.text(" and "),
+      html.text("/"),
       html.code([], [html.text("end")]),
-      html.text("."),
+      html.text(
+        " syntax is only valid as a keyword argument to macros such as ",
+      ),
+      html.code([], [html.text("def")]),
+      html.text(", "),
+      html.code([], [html.text("if")]),
+      html.text(", and "),
+      html.code([], [html.text("case")]),
+      html.text(", not for grouping expressions in a bare assignment."),
     ]),
     html.pre([], [
       html.code([attr.class("language-elixir")], [
         html.text(
           "defmodule Wibble do
   def main() do
-    x = do
-      print(1)
+    x = (
+      IO.puts(1)
       2
-    end
+    )
     y = x * (x + 10) # parentheses are used to change arithmetic operations order
     y
   end


### PR DESCRIPTION
Fixes #298

## What

The Blocks section of the Gleam for Elixir users cheatsheet showed this code as valid Elixir:

```elixir
x = do
  print(1)
  2
end
```

This is **not valid Elixir**. `do/end` in Elixir is only valid as a keyword argument to macros such as `def`, `if`, and `case` — it cannot be used to group expressions in a bare variable assignment.

## Fix

- Updated the code example to use parentheses, which is the correct Elixir syntax for grouping expressions in an assignment context
- Updated the description text to accurately explain when `do/end` vs parentheses are used in Elixir

The corrected example:

```elixir
x = (
  IO.puts(1)
  2
)
```

This matches what `inoas` verified in the issue comments (referencing the [Elixir syntax reference](https://hexdocs.pm/elixir/1.16.1/syntax-reference.html#blocks)).