### PR TITLE
Update command-line reference with `export escript` command

### DIFF
--- a/src/website/command_line_reference.gleam
+++ b/src/website/command_line_reference.gleam
@@ -218,6 +218,13 @@ pub fn page(ctx: site.Context) -> fs.File {
     ]),
     html.p([], [html.code([], [html.text("gleam export erlang-shipment")])]),
     html.p([], [html.text("Precompiled Erlang, suitable for deployment")]),
+    html.h3([attr.id("export-escript")], [
+      html.code([], [html.text("export escript")]),
+    ]),
+    html.p([], [html.code([], [html.text("gleam export escript")])]),
+    html.p([], [
+      html.text("Escript file, for running in a script-like manner"),
+    ]),
     html.h3([attr.id("export-hex-tarball")], [
       html.code([], [html.text("export hex-tarball")]),
     ]),


### PR DESCRIPTION
I noticed the new `export escript` command was not documented on the [website](https://gleam.run/command-line-reference/).

Hopefully the phrasing is suitable otherwise I'd be happy to adjust it to your liking.