### PR TITLE
Update FAQ on Elixir and Gleam type systems

### DIFF
--- a/documentation/frequently-asked-questions.djot
+++ b/documentation/frequently-asked-questions.djot
@@ -164,8 +164,6 @@ Here’s a non-exhaustive list of differences:
     annotations, but they are not required.
   - Elixir does not support generics, while Gleam does. This makes Gleam's type
     system more precise in some respects.
-  - Elixir does not support recursive type declarations, while Gleam does.
-    This makes some data structures impossible to represent in Elixir.
   - Elixir does not support nominal types and therefore cannot distinguish between
     types that are semantically distinct but structurally the same, while Gleam can.
   - Elixir does not integrate with any other type system. Gleam generates

--- a/documentation/frequently-asked-questions.djot
+++ b/documentation/frequently-asked-questions.djot
@@ -167,10 +167,10 @@ Here’s a non-exhaustive list of differences:
     annotations, but they are not required.
   - Elixir does not support generics, while Gleam does. This makes Gleam's type
     system more precise in some respects.
-  - Elixir does not support recursive types, while Gleam's type system does.
+  - Elixir does not support recursive types, while Gleam does.
     This makes some data structures impossible to represent in Elixir.
-  - Elixir does not integrate with any other system. Gleam's type
-    system generates BEAM typespecs, TypeScript definitions, and API type
+  - Elixir does not integrate with any other type system. Gleam generates
+    BEAM typespecs, TypeScript definitions, and API type
     information can be exported to be used by other external tools.
   - Elixir's type inference aims to minimize false positive warnings, emitting
     violations only when a program always fails at runtime. Gleam's type inference

--- a/documentation/frequently-asked-questions.djot
+++ b/documentation/frequently-asked-questions.djot
@@ -152,23 +152,22 @@ Here’s a non-exhaustive list of differences:
 - Elixir and Gleam both have compile type type checking, but their respective
   type systems are very different, so they offer a different development
   experience.
-  - Elixir has a set-theoretic type system, where types can be composed with
-    unions, intersections, and negations. Gleam's type system is based on
+  - Elixir has a set-theoretic type system. Gleam's type system is based on
     the same Hindley-Milner type system that underpins OCaml, Haskell, F#, etc.
   - Elixir's type system is gradual, so portions of the codebase can be
     dynamically typed. Gleam is always fully statically typed.
   - Elixir's type system is structural, while Gleam's type system is nominal.
-    Elixir's types can be more precise in many respects. On the other hand,
-    Elixir's types are in active development and lacks common features (mentioned below).
-  - Elixir does not have opaque types and therefore cannot distinguish between
-    types that are semantically distinct but structurally the same, while Gleam can.
+    Elixir's types can be more precise in many respects.
+  - Elixir's type system is in development, while Gleam's is more mature.
   - Elixir does not support type annotations, so the programmer cannot restrict
     the type beyond what Elixir infers them to be. Gleam supports type
     annotations, but they are not required.
   - Elixir does not support generics, while Gleam does. This makes Gleam's type
     system more precise in some respects.
-  - Elixir does not support recursive types, while Gleam does.
+  - Elixir does not support recursive type declarations, while Gleam does.
     This makes some data structures impossible to represent in Elixir.
+  - Elixir does not support nominal types and therefore cannot distinguish between
+    types that are semantically distinct but structurally the same, while Gleam can.
   - Elixir does not integrate with any other type system. Gleam generates
     BEAM typespecs, TypeScript definitions, and API type
     information can be exported to be used by other external tools.

--- a/documentation/frequently-asked-questions.djot
+++ b/documentation/frequently-asked-questions.djot
@@ -159,7 +159,7 @@ Here’s a non-exhaustive list of differences:
     dynamically typed. Gleam is always fully statically typed.
   - Elixir's type system is structural, while Gleam's type system is nominal.
     Elixir's types can be more precise in many respects. On the other hand,
-    Elixir is still in active development and lacks common features (discussed below).
+    Elixir's types are in active development and lacks common features (mentioned below).
   - Elixir does not have opaque types and therefore cannot distinguish between
     types that are semantically distinct but structurally the same, while Gleam can.
   - Elixir does not support type annotations, so the programmer cannot restrict

--- a/documentation/frequently-asked-questions.djot
+++ b/documentation/frequently-asked-questions.djot
@@ -152,6 +152,7 @@ Here’s a non-exhaustive list of differences:
 - Elixir and Gleam both have compile type type checking, but their respective
   type systems are very different, so they offer a different development
   experience.
+
   - Elixir has a set-theoretic type system. Gleam's type system is based on
     the same Hindley-Milner type system that underpins OCaml, Haskell, F#, etc.
   - Elixir's type system is gradual, so portions of the codebase can be

--- a/documentation/frequently-asked-questions.djot
+++ b/documentation/frequently-asked-questions.djot
@@ -152,32 +152,29 @@ Here’s a non-exhaustive list of differences:
 - Elixir and Gleam both have compile type type checking, but their respective
   type systems are very different, so they offer a different development
   experience.
+  - Elixir has a set-theoretic type system, where types can be composed with
+    unions, intersections, and negations. Gleam's type system is based on
+    the same Hindley-Milner type system that underpins OCaml, Haskell, F#, etc.
   - Elixir's type system is gradual, so portions of the codebase can be
     dynamically typed. Gleam is always fully statically typed.
   - Elixir's type system is structural, while Gleam's type system is nominal.
-    This means Elixir's types can be more precise in some respects, but it
-    cannot distinguish between types that are semantically distinct but
-    structurally the same.
+    Elixir's types can be more precise in many respects. On the other hand,
+    Elixir is still in active development and lacks common features (discussed below).
+  - Elixir does not have opaque types and therefore cannot distinguish between
+    types that are semantically distinct but structurally the same, while Gleam can.
   - Elixir does not support type annotations, so the programmer cannot restrict
     the type beyond what Elixir infers them to be. Gleam supports type
     annotations, but they are not required.
   - Elixir does not support generics, while Gleam does. This makes Gleam's type
     system more precise in some respects.
-  - Elixir's type system does not support recursive types, while Gleam's type
-    system does.
-    This makes some data structures impossible to represent in Elixir's type
-    system.
-  - Elixir's type checker is more likely to have false-negatives, while Gleam
-    is more likely to have false-positives. This means Gleam may reject a
-    program that is actually safe, but Elixir may accept a program that crashes
-    at runtime due to a type error.
-  - Elixir's type system does not integrate with any other system. Gleam's type
+  - Elixir does not support recursive types, while Gleam's type system does.
+    This makes some data structures impossible to represent in Elixir.
+  - Elixir does not integrate with any other system. Gleam's type
     system generates BEAM typespecs, TypeScript definitions, and API type
     information can be exported to be used by other external tools.
-  - Elixir's type system is the product of novel research specifically for
-    Elixir. Gleam's type system is based on the same Hindley-Milner type system
-    that underpins OCaml, Haskell, F#, etc. 
-  - Elixir's system is set-theoretic. Gleam's system is type-theoretic.
+  - Elixir's type inference aims to minimize false positive warnings, emitting
+    violations only when a program always fails at runtime. Gleam's type inference
+    will reject valid programs in favor of finding more bugs.
 - Elixir has a powerful macro system, Gleam has no metaprogramming features.
 - Elixir’s compiler is written in Erlang and Elixir, Gleam’s is written in Rust.
 - Gleam has a more traditional C family style syntax.


### PR DESCRIPTION
I am trying to organize the differences so they work more top to bottom. We first start with the overall description of the systems, and then we break it down.

I am also careful about the words here, trying to distinguish between the type system and the implementation, as I can see this becoming a more general discussion between set-theoretic types and HM, so I want to make it clear what is Elixir's fault and what is a type system limitation.

A couple notes:

* Elixir is type-theoretic too, so I removed that altogether
* Only certain aspects of Elixir's type system are novel. Overall set theoretic types are a few decades old :)
* Set-theoretic types are more expressive than HM and it is proven intersection types are a superset of HM inference (I can dig the exact paper later). However, we cannot affirm that for Elixir in particular because it is still in development