### PR TITLE
Fix typo in FAQ regarding Elixir and Gleam compile time type checking

### DIFF
--- a/documentation/frequently-asked-questions.djot
+++ b/documentation/frequently-asked-questions.djot
@@ -149,7 +149,7 @@ popular and a great language!
 
 Here’s a non-exhaustive list of differences:
 
-- Elixir and Gleam both have compile type type checking, but their respective
+- Elixir and Gleam both have compile time type checking, but their respective
   type systems are very different, so they offer a different development
   experience.
   - Elixir's type system is gradual, so portions of the codebase can be


### PR DESCRIPTION
Fixes a typo in the Elixir vs. Gleam comparison docs, changing “compile type type checking” to “compile time type checking” for clarity and correctness.