### PR TITLE
fix typo in gleam cheatsheet (gleam for rust users)

### DIFF
--- a/src/website/cheatsheet.gleam
+++ b/src/website/cheatsheet.gleam
@@ -7403,7 +7403,7 @@ fn mul(x, y) {
     html.p([], [
       html.text("Rust functions "),
       html.strong([], [html.text("always")]),
-      html.text("need type annotations."),
+      html.text(" need type annotations."),
     ]),
     html.pre([], [
       html.code([attr.class("language-rust")], [


### PR DESCRIPTION
Fix this typo, no space after

> Rust functions **always**need type annotations.

<img width="953" height="369" alt="Screenshot From 2026-06-14 17-08-03" src="https://github.com/user-attachments/assets/80857e98-8b3b-47de-a557-b65eeee82ac3" />
