### PR TITLE
Correct sans io return type

### DIFF
--- a/documentation/conventions-patterns-anti-patterns.djot
+++ b/documentation/conventions-patterns-anti-patterns.djot
@@ -486,7 +486,7 @@ pub fn create_user_request(name: String) -> Request(String) {
 }
 
 /// Parse a response from the create-user endpoint.
-pub fn create_user_response(response: Response(String)) -> Result(Nil, ApiError) {
+pub fn create_user_response(response: Response(String)) -> Result(User, ApiError) {
   case response.status {
     201 -> Ok(User(name: response.body))
     409 -> Error(UserNameAlreadyInUse)

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -174,10 +174,7 @@ pub fn page_layout(
 
 // Page elements
 
-fn head_elements(
-  page: PageMeta,
-  ctx: site.Context,
-) -> List(element.Element(a)) {
+fn head_elements(page: PageMeta, ctx: site.Context) -> List(element.Element(a)) {
   let metatag = fn(property, content) {
     html.meta([attr("property", property), attr("content", content)])
   }


### PR DESCRIPTION
The example for the sans-io pattern had `Result(Nil, ApiError)` where it should be `Result(User, ApiError)`


also ran `gleam format`