### PR TITLE
Correct the return type in sans-io pattern example

### DIFF
--- a/documentation/conventions-patterns-anti-patterns.djot
+++ b/documentation/conventions-patterns-anti-patterns.djot
@@ -486,7 +486,7 @@ pub fn create_user_request(name: String) -> Request(String) {
 }
 
 /// Parse a response from the create-user endpoint.
-pub fn create_user_response(response: Response(String)) -> Result(Nil, ApiError) {
+pub fn create_user_response(response: Response(String)) -> Result(User, ApiError) {
   case response.status {
     201 -> Ok(User(name: response.body))
     409 -> Error(UserNameAlreadyInUse)


### PR DESCRIPTION
The example for the sans-io pattern had `Result(Nil, ApiError)` where it should be `Result(User, ApiError)`