### PR TITLE
Fix horizontal code overflow

### DIFF
--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -828,6 +828,7 @@ pre code {
 }
 
 .page pre {
+  overflow-x: auto;
   overflow-y: auto;
   margin: var(--gap-3) 0 var(--gap-4) 0;
   padding: var(--gap-2) var(--gap-2);


### PR DESCRIPTION
This fixes the horizontal overscroll reported in #594 on docs pages with long code snippets.

The change is intentionally small: it keeps code blocks scrollable inside the block by enabling horizontal overflow on `.page pre`, instead of letting long content expand the page width.

Why this should help:
- the issue report shows the overflow happening on docs pages with long `code` content
- the existing CSS already wraps code text, but the page-level pre container did not contain horizontal overflow
- this keeps the fix localized to rendered documentation pages

Validation:
- reviewed the relevant markup and styles in `src/website/page.gleam` and `priv/styles/main.css`
- no local Gleam runtime was available in this environment, so I validated by code inspection only

Fixes #594