### PR TITLE
Reconcile CPU architectures in precompiled binary installation examples

### DIFF
--- a/src/website/install.gleam
+++ b/src/website/install.gleam
@@ -485,13 +485,13 @@ Verify the checksum is correct. If this command shows a warning then delete
 both files and start again.
 
 ```
-sha256sum -c gleam-v1.14.0-x86_64-unknown-linux-musl.tar.gz.sha256
+sha256sum -c gleam-v1.14.0-aarch64-unknown-linux-musl.tar.gz.sha256
 ```
 
 Extract the `gleam` program from the tarball.
 
 ```
-tar xf gleam-v1.14.0-x86_64-unknown-linux-musl.tar.gz
+tar xf gleam-v1.14.0-aarch64-unknown-linux-musl.tar.gz
 ```
 
 Make the binary executable and place it in a directory on your `PATH`.


### PR DESCRIPTION
The instructions on the _Precompiled executable from GitHub_ pages (such as https://gleam.run/install/macos/gleam/github/) provide examples for downloading, verifying, and extracting the Gleam binary such that it is executable and ready to roll. However, the CPU architectures used throughout the examples are not consistent. Compare, for example, the download block versus the extract block:

> `wget https://github.com/gleam-lang/gleam/releases/download/v1.14.0/gleam-v1.14.0-aarch64-unknown-linux-musl.tar.gzk`

> `tar xf gleam-v1.14.0-x86_64-unknown-linux-musl.tar.gz`

A minor detail overall, I think, but also a small improvement that might prevent a newcomer from getting hung up!

I chose aarch64 here mostly because that's what the examples start with.