### PR TITLE
Update escript instructions & package versions in example

### DIFF
--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -1459,43 +1459,15 @@ into a single file that can be easily shared with others.",
       html.em([], [html.text("escript")]),
       html.text(
         ", which is part
-of the Erlang runtime. Add the ",
-      ),
-      html.code([], [html.text("gleescript")]),
-      html.text(" package as a dependency."),
-    ]),
-    highlighted_shell_pre_code(
-      "gleam add --dev gleescript
-",
-    ),
-    html.p([], [
-      html.text("The "),
-      html.code([], [html.text("--dev")]),
-      html.text(
-        " flag is used to indicate that this package is only used for building,
-developing, and testing the project, and should not be included in the final
-production builds. The build tool will then add ",
-      ),
-      html.code([], [html.text("gleescript")]),
-      html.text(" to the "),
-      html.code([], [html.text("[dev_dependencies]")]),
-      html.text(" section rather than the regular "),
-      html.code([], [html.text("[dependencies]")]),
-      html.text(" section."),
-    ]),
-    html.p([], [
-      html.text("Once added run "),
-      html.code([], [html.text("gleam run -m gleescript")]),
-      html.text(
-        " to compile your package into an escript file, which will be written to ",
+of the Erlang runtime. Gleam can compile your package into an escript file,
+which will be written to ",
       ),
       html.code([], [html.text("./vars")]),
       html.text("."),
     ]),
     highlighted_shell_pre_code(
       "# Compile the program to an escript
-gleam build
-gleam run -m gleescript
+gleam export escript
 
 # Run the program
 ./vars get USER

--- a/src/website/page.gleam
+++ b/src/website/page.gleam
@@ -1202,9 +1202,9 @@ need to add some dependencies that provide this functionality.",
 version = \"1.0.0\"
 
 [dependencies]
-gleam_stdlib = \">= 0.34.0 and < 2.0.0\"
-envoy = \">= 1.0.1 and < 2.0.0\"
-argv = \">= 1.0.2 and < 2.0.0\"
+gleam_stdlib = \">= 1.0.0 and < 2.0.0\"
+envoy = \">= 1.2.0 and < 2.0.0\"
+argv = \">= 1.1.0 and < 2.0.0\"
 
 [dev_dependencies]
 gleeunit = \">= 1.0.0 and < 2.0.0\"
@@ -1212,10 +1212,10 @@ gleeunit = \">= 1.0.0 and < 2.0.0\"
     ),
     html.p([], [
       html.text("The "),
-      html.code([], [html.text(">= 1.0.1 and < 2.0.0")]),
+      html.code([], [html.text(">= 1.2.0 and < 2.0.0")]),
       html.text(
         " version constraint means that the project wants any version
-greater than or equal to 1.0.1, but less than 2.0.0, which will maximise compatibility while
+greater than or equal to 1.2.0, but less than 2.0.0, which will maximise compatibility while
 avoiding breaking changes as Hex packages adhere to ",
       ),
       html.a([attr.href("https://semver.org/")], [


### PR DESCRIPTION
I've updated the instructions for sharing your program via an escript file to use the new `gleam export escript` command.

While at that I've also updated the version numbers for the packages in the example.

I wouldn't normally have done this but I've thought since `gleam_stdlib` is now `1.0.0` it would be nice to have that reflected in there.