### PR TITLE
Format sublist in FAQ page

### DIFF
--- a/documentation/frequently-asked-questions.djot
+++ b/documentation/frequently-asked-questions.djot
@@ -152,6 +152,7 @@ Here’s a non-exhaustive list of differences:
 - Elixir and Gleam both have compile time type checking, but their respective
   type systems are very different, so they offer a different development
   experience.
+
   - Elixir's type system is gradual, so portions of the codebase can be
     dynamically typed. Gleam is always fully statically typed.
   - Elixir's type system is structural, while Gleam's type system is nominal.


### PR DESCRIPTION
First, thank you to the Gleam dev team for creating a wonderful language and community.

This PR addresses a small formatting issue in the FAQ page. Under the section "How does Gleam compare to Elixir?", I believe the first bullet point should have a sublist nested underneath it. djot requires a blank line before the sublist to render properly.


**Formatting before:**
<img width="2100" height="1245" alt="Screenshot From 2026-06-26 21-40-15" src="https://github.com/user-attachments/assets/0040a362-d6e7-451b-b5f3-6e2466b7f2ca" />


**Formatting after:**
<img width="2100" height="1245" alt="Screenshot From 2026-06-26 21-39-09" src="https://github.com/user-attachments/assets/ae0e283e-afac-4453-97d4-d8412a9455ba" />
