### PR TITLE
fix an unwanted line break on the FAQ page

### DIFF
--- a/documentation/frequently-asked-questions.djot
+++ b/documentation/frequently-asked-questions.djot
@@ -118,7 +118,7 @@ language surface area. It compiles to native code and has little-to-no runtime.
 
 - Gleam is a high-level immutable functional language with automatic garbage
 collection, no metaprogramming, and a small and easy to learn language surface
-area. It runs on Erlang and JavaScript virtual machines.
+area\. It runs on Erlang and JavaScript virtual machines.
 
 Both languages have strong static type systems, and Gleam's developer tooling
 were inspired in-part by Rust's.


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/website/issues/660

The djot parser currently has a bug where it mistakenly identifies the third line as a list-marker (`a.`).

More of a temporary fix, until the jot package parses this correctly!