### PR TITLE
Website doesn't respect Chrome's font size setting

### DIFF
--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -59,24 +59,24 @@
   --width-content: 960px;
 
   /* TODO: condense these into a few appopriatedly named variables */
-  --font-size-small: 12px;
-  --font-size-code: 16px;
-  --font-size-normal: 18px;
-  --font-size-navbar: 18px;
-  --font-size-hero-button: 24px;
-  --font-size-pair-text: 22px;
-  --font-size-friendly-text: 24px;
-  --font-size-still-here-subtitle: 24px;
-  --font-size-still-here-button: 24px;
-  --font-size-hero-subtitle: 24px;
-  --font-size-logo: 28px;
-  --font-size-hero: 36px;
-  --font-size-pair-title: 36px;
-  --font-size-hero-title: 36px;
-  --font-size-still-here-title: 36px;
-  --font-size-footer-logo: 36px;
-  --font-size-friendly-title: 48px;
-  --font-size-sponsors-title: 48px;
+  --font-size-small: 0.75rem;
+  --font-size-code: 1rem;
+  --font-size-normal: 1.125rem;
+  --font-size-navbar: 1.125rem;
+  --font-size-hero-button: 1.5rem;
+  --font-size-pair-text: 1.375rem;
+  --font-size-friendly-text: 1.5rem;
+  --font-size-still-here-subtitle: 1.5rem;
+  --font-size-still-here-button: 1.5rem;
+  --font-size-hero-subtitle: 1.5rem;
+  --font-size-logo: 1.75rem;
+  --font-size-hero: 2.25rem;
+  --font-size-pair-title: 2.25rem;
+  --font-size-hero-title: 2.25rem;
+  --font-size-still-here-title: 2.25rem;
+  --font-size-footer-logo: 2.25rem;
+  --font-size-friendly-title: 3rem;
+  --font-size-sponsors-title: 3rem;
 
   --font-weight-normal: 400;
   --font-weight-title-bold: 700;
@@ -112,7 +112,7 @@ body {
   background-color: var(--color-underwater-blue);
   color: var(--color-text-main);
   font-family: var(--font-family-normal);
-  font-size: var(--font-size-normal);
+  font-size: 18px;
 }
 
 h1,

--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -112,7 +112,7 @@ body {
   background-color: var(--color-underwater-blue);
   color: var(--color-text-main);
   font-family: var(--font-family-normal);
-  font-size: 18px;
+  font-size: var(--font-size-normal);
 }
 
 h1,


### PR DESCRIPTION
Fixes #665 

Fixes an issue where the site would ignore Chrome's font size setting. The browser's zoom works fine currently up to 200% per [WCAG's success criterion](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html). This PR will ensure the the user's chosen default font size is respected when scaling font sizes without zoom.

### Things I tested
- Did a quick smoke test on  `/`, `/news`, `/single-file-gleam-beam-programs-with-escript`, `/documentation`, `/frequently-asked-questions`, `/sponsor`, `/case-studies`, and `/case-studies/uncover` with Chrome font size set to medium (16px). No visual regressions compared to https://gleam.run/
- Did browser zoom up to 200%, site is still readable at all zoom levels
- Set font size to `Large` in chrome (20px default), font scales appropriately.

### Notes
- It took a bit to find consistent advice on how to handle this, but the best write up on what units to use was [here](https://www.joshwcomeau.com/css/surprising-truth-about-pixels-and-accessibility/). 
  - tl;dr - The suggestion seemed to be to leave the root `font-size` alone and all font sizes should be in `rem`s. So if the user has their browser font size set to `16px` (Medium in chrome), text with font size `1.125rem` will be ~`18px`. 
- the current `font-size` of the `body` on the site is `18px`. To keep things the same, I made no changes and its still set to `font-size: var(--font-size-normal);`. I _think_ this is preferred rather than overriding it with a hardcoded `px` value.