### PR TITLE
fix: allow nix codeblocks in djot content

### DIFF
--- a/src/website/site.gleam
+++ b/src/website/site.gleam
@@ -2255,6 +2255,7 @@ pub fn parse_djot(string: String) -> jot.Document {
         | jot.Codeblock(language: option.Some("systemd"), ..)
         | jot.Codeblock(language: option.Some("markdown"), ..)
         | jot.Codeblock(language: option.Some("md"), ..)
+        | jot.Codeblock(language: option.Some("nix"), ..)
         | jot.Codeblock(language: option.Some("txt"), ..)
         | jot.Codeblock(language: option.Some("text"), ..) -> container
 


### PR DESCRIPTION
Hey : ) ! While fixing something here I got this panic error when launching the project, which apparently is what's making the CI fail as well (introduced by [d87d300](https://github.com/gleam-lang/website/commit/d87d30029b8ddf90c1a573413ea0253d3ec0890b)). This should fix it !

<img width="1269" height="260" alt="image" src="https://github.com/user-attachments/assets/64eee904-57c7-4fad-82b9-f91c20eb03b5" />

<img width="1078" height="230" alt="image" src="https://github.com/user-attachments/assets/0e96e70a-81ae-497e-9b03-37f5669a6953" />
