### PR TITLE
fix(case-studies): swap inverted headers for strand and uncover articles

### DIFF
--- a/pages/case-studies/strand.djot
+++ b/pages/case-studies/strand.djot
@@ -1,7 +1,7 @@
 ---
-title = "No room for error"
-subtitle = "A case study of Gleam in production at Uncover"
-description = "A case study of Gleam in production at Uncover"
+title = "Optimising for maintainability"
+subtitle = "A case study of Gleam in production at Strand"
+description = "A case study of Gleam in production at Strand"
 meta_title = "No room for error | A case study of Gleam in production at Strand"
 
 published = 2025-07-11

--- a/pages/case-studies/strand.djot
+++ b/pages/case-studies/strand.djot
@@ -2,7 +2,7 @@
 title = "Optimising for maintainability"
 subtitle = "A case study of Gleam in production at Strand"
 description = "A case study of Gleam in production at Strand"
-meta_title = "No room for error | A case study of Gleam in production at Strand"
+meta_title = "Optimising for maintainability | A case study of Gleam in production at Strand"
 
 published = 2025-07-11
 featured_quote = "Almost by accident, what we launched as a prototype became a business-critical application"

--- a/pages/case-studies/uncover.djot
+++ b/pages/case-studies/uncover.djot
@@ -2,7 +2,7 @@
 title = "No room for error"
 subtitle = "A case study of Gleam in production at Uncover"
 description = "A case study of Gleam in production at Uncover"
-meta_title = "Optimising for maintainability | A case study of Gleam in production at Uncover"
+meta_title = "No room for error | A case study of Gleam in production at Uncover"
 
 published = 2025-12-03
 featured_quote = "We wouldn't be using Gleam if it wasn't a safe, sensible - almost boring - choice."

--- a/pages/case-studies/uncover.djot
+++ b/pages/case-studies/uncover.djot
@@ -1,7 +1,7 @@
 ---
-title = "Optimising for maintainability"
-subtitle = "A case study of Gleam in production at Strand"
-description = "A case study of Gleam in production at Strand"
+title = "No room for error"
+subtitle = "A case study of Gleam in production at Uncover"
+description = "A case study of Gleam in production at Uncover"
 meta_title = "Optimising for maintainability | A case study of Gleam in production at Uncover"
 
 published = 2025-12-03


### PR DESCRIPTION
While navigating through the website and reading [here](https://gleam.run/case-studies/), I noticed the articles titles / subtitles were inverted.
This restores the headers back to their respective articles.