### PR TITLE
feat: add v1.18 to roadmap

### DIFF
--- a/src/website/roadmap.gleam
+++ b/src/website/roadmap.gleam
@@ -116,7 +116,7 @@ const done = [
       "List prepending in constant expressions",
       "Build tool support for mts, cts, jsx, and tsx external files",
       "Formatter tuple handling improvements",
-      "Language server and and remove anonymous function code actions",
+      "Language server and remove anonymous function code actions",
       "Language server replace hole with type code action",
     ],
   ),

--- a/src/website/roadmap.gleam
+++ b/src/website/roadmap.gleam
@@ -63,6 +63,24 @@ const research = [
 
 const done = [
   Release(
+    version: "v1.18",
+    date: calendar.Date(2026, calendar.July, 29),
+    items: [
+      "Language server go-to-definition, find references, and rename for record fields",
+      "Pipe rewriting syntax deprecation",
+      "Singleton values for JavaScript variants with no fields",
+      "Git dependency subdirectory support",
+      "Authenticated requests to Hex with `HEXPM_READ_API_KEY` environment variable",
+      "Hexdocs URL format update in generated links",
+      "Language server automatic import updates on module rename",
+      "Language server generate missing type definition code action",
+      "Language server rewrite int in different base code action",
+      "Language server type variable renaming",
+      "Language server discard unused variable code action",
+      "Formatter performance improvements",
+    ],
+  ),
+  Release(
     version: "v1.17",
     date: calendar.Date(2026, calendar.June, 2),
     items: [


### PR DESCRIPTION
This adds the latest release ([v1.18.0](https://github.com/gleam-lang/gleam/blob/main/changelog/v1.18.md)) to the **Version History** section in the **/roadmap** page.

I kinda cherry-picked what I considered "more important" new features, taking inspiration from how the other releases' items lists were added compared to their changelog file, feel free to suggest / edit something if needed 🙃.